### PR TITLE
New player command added for Windows

### DIFF
--- a/src/gui/components/Terminal.tsx
+++ b/src/gui/components/Terminal.tsx
@@ -5,6 +5,7 @@ import {
     useRef,
     useState,
 } from 'react';
+import { isWindows, newPlayerWindow } from '../system/menu';
 import termstyles from './Terminal.module.css';
 
 const InputStyle: React.CSSProperties = {
@@ -213,6 +214,15 @@ export const TerminalView: FunctionComponent<TerminalViewProps> = ({
         }
 
         const handleKeyDown = (e: KeyboardEvent) => {
+            if (isWindows) {
+                if (e.key === 'p' && e.ctrlKey) {
+                    e.preventDefault();
+                    newPlayerWindow().catch((err) => {
+                        console.error('Failed to open new player window', err);
+                    });
+                    return;
+                }
+            }
             if (flow[opIndex].choices) {
                 if (e.key === 'ArrowUp') {
                     e.preventDefault();


### PR DESCRIPTION
## What
New player command added for Windows `ctrl + p`

## Why
Otherwise, there's no way to start a new substream client on Windows since it doesn't let you run the app