### PR TITLE
Implemented new energy bar design

### DIFF
--- a/src/examples/spaceshooter/renderer/EnergyBar.module.css
+++ b/src/examples/spaceshooter/renderer/EnergyBar.module.css
@@ -16,15 +16,9 @@
 
 .energyFill {
     height: 100%;
-    background: linear-gradient(
-        90deg,
-        rgb(255, 64, 64),
-        yellow,
-        rgb(46, 194, 46)
-    );
-    background-size: 400px 100%;
+    background-size: 100% 100%;
     background-position: left;
-    transition: width 1s ease-in-out;
+    transition: width 0.1s cubic-bezier(0.4, 0, 1, 1), background-color 0.2s ease-in-out;
     position: relative;
     border-radius: 4px;
     overflow: hidden;

--- a/src/examples/spaceshooter/renderer/EnergyBar.tsx
+++ b/src/examples/spaceshooter/renderer/EnergyBar.tsx
@@ -25,11 +25,19 @@ export default function EnergyBar(props: { energy: number }) {
         });
     }, []);
 
+    const energyColor = useMemo(
+        () => getEnergyColor(props.energy),
+        [props.energy],
+    );
+
     return (
         <div className={styles.energyBar}>
             <div
                 className={styles.energyFill}
-                style={{ width: `${props.energy}%` }}
+                style={{
+                    width: `${props.energy}%`,
+                    backgroundColor: energyColor,
+                }}
             >
                 <div className={styles.energyReflection}></div>
                 {bubbles}
@@ -37,3 +45,28 @@ export default function EnergyBar(props: { energy: number }) {
         </div>
     );
 }
+
+const lerp = (start: number, end: number, t: number): number => {
+    return start + t * (end - start);
+};
+
+const getEnergyColor = (energy: number): string => {
+    const green = { r: 46, g: 194, b: 46 };
+    const yellow = { r: 199, g: 201, b: 50 };
+    const red = { r: 255, g: 64, b: 64 };
+    let r, g, b;
+    if (energy > 50) {
+        // Interpolate between yellow and green
+        const t = (energy - 50) / 50;
+        r = lerp(yellow.r, green.r, t);
+        g = lerp(yellow.g, green.g, t);
+        b = lerp(yellow.b, green.b, t);
+    } else {
+        // Interpolate between red and yellow
+        const t = energy / 50;
+        r = lerp(red.r, yellow.r, t);
+        g = lerp(red.g, yellow.g, t);
+        b = lerp(red.b, yellow.b, t);
+    }
+    return `rgb(${Math.round(r)}, ${Math.round(g)}, ${Math.round(b)})`;
+};


### PR DESCRIPTION
## What
Previously, the energy bar had a bug where in certain screen ratios, the energy bar gradient would repeat. 
### Old:
![image](https://github.com/user-attachments/assets/d703e7d0-7dcc-46f4-98c1-ea8132030cd8)

### New:
Now the color is solid and changes based on how much energy you have:
![image](https://github.com/user-attachments/assets/ffb6536b-74a0-4f8e-b3a5-6cb0cee911d5)
