### PR TITLE
Enemy location indicators

### DIFF
--- a/src/examples/spaceshooter/renderer/EnemyLocation.tsx
+++ b/src/examples/spaceshooter/renderer/EnemyLocation.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+// import styles from './EndRoundLeaderBoard.module.css';
+import { PlayerInfo } from './PlayerHUD';
+import { WorldRef } from './ShooterRenderer';
+
+function Enemy({ x, y }: { x: number; y: number }) {
+    return <div style={{ position: 'absolute', left: x, bottom: y }}>👾</div>;
+}
+
+function getAngleRad(ax: number, ay: number, bx: number, by: number) {
+    const dx = bx - ax;
+    const dy = by - ay;
+    return Math.atan2(dy, dx);
+}
+
+function polarToCartesian(
+    centerX: number,
+    centerY: number,
+    radius: number,
+    angleRad: number,
+) {
+    return {
+        x: centerX + radius * Math.cos(angleRad),
+        y: centerY + radius * Math.sin(angleRad),
+    };
+}
+
+export default function EnemyLocation({
+    worldRef,
+    players,
+    peerId,
+}: {
+    worldRef: WorldRef;
+    players: PlayerInfo[];
+    peerId: string;
+}) {
+    const componentRef = useRef<HTMLDivElement>(null);
+    const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
+
+    useEffect(() => {
+        // Function to update dimensions
+        const updateDimensions = () => {
+            if (componentRef.current) {
+                setDimensions({
+                    width: componentRef.current.offsetWidth,
+                    height: componentRef.current.offsetHeight,
+                });
+            }
+        };
+
+        // Set initial dimensions
+        updateDimensions();
+
+        window.addEventListener('resize', updateDimensions);
+
+        return () => window.removeEventListener('resize', updateDimensions);
+    }, []); // Empty dependency array means this effect runs once on mount
+
+    if (!worldRef.current) {
+        return null;
+    }
+
+    // Memoize this?
+    // const playerShip = players.find((player) => player.id === peerId)?.ship;
+
+    const playerShip = players.find((player) => player.id === peerId)?.ship;
+    const playerX = playerShip
+        ? worldRef.current.components.position.data.x[playerShip]
+        : 0;
+    const playerY = playerShip
+        ? worldRef.current.components.position.data.y[playerShip]
+        : 0;
+
+    const centerX = dimensions.width / 2;
+    const centerY = dimensions.height / 2;
+    const radius = 200; // Distance in px from the center
+
+    return (
+        <div
+            ref={componentRef}
+            style={{
+                position: 'absolute',
+                width: '100%',
+                height: '100%',
+                backgroundColor: 'rgba(255, 0, 0, 0.1)',
+            }}
+        >
+            {players.map((player) => {
+                if (player.id !== peerId) {
+                    const enemyX =
+                        worldRef.current.components.position.data.x[
+                            player.ship
+                        ];
+                    const enemyY =
+                        worldRef.current.components.position.data.y[
+                            player.ship
+                        ];
+                    const angle = getAngleRad(playerX, playerY, enemyX, enemyY);
+                    const { x, y } = polarToCartesian(
+                        centerX,
+                        centerY,
+                        radius,
+                        angle,
+                    );
+                    return (
+                        <div key={player.id}>
+                            {player.id}
+                            <br />
+                            {`Angle: ${angle.toFixed(2)}°`}
+                            <Enemy x={x} y={y} />
+                        </div>
+                    );
+                }
+                return (
+                    <div key={player.id}>
+                        {player.id} (you)
+                        <br />
+                    </div>
+                );
+            })}
+        </div>
+    );
+}

--- a/src/examples/spaceshooter/renderer/EnemyLocation.tsx
+++ b/src/examples/spaceshooter/renderer/EnemyLocation.tsx
@@ -52,6 +52,7 @@ export default function EnemyLocation({
 }) {
     const componentRef = useRef<HTMLDivElement>(null);
     const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
+    const [hypotenuse, setHypotenuse] = useState(0);
 
     useEffect(() => {
         // Function to update dimensions
@@ -61,6 +62,12 @@ export default function EnemyLocation({
                     width: componentRef.current.offsetWidth,
                     height: componentRef.current.offsetHeight,
                 });
+                setHypotenuse(
+                    Math.sqrt(
+                        componentRef.current.offsetWidth ** 2 +
+                            componentRef.current.offsetHeight ** 2,
+                    ),
+                );
             }
         };
 
@@ -89,7 +96,7 @@ export default function EnemyLocation({
 
     const centerX = dimensions.width / 2;
     const centerY = dimensions.height / 2;
-    const radius = dimensions.height / 2;
+    const radius = hypotenuse / 2;
 
     return (
         <div
@@ -121,8 +128,8 @@ export default function EnemyLocation({
                     return (
                         <Enemy
                             key={player.id}
-                            x={x}
-                            y={y}
+                            x={Math.min(dimensions.width, Math.max(x, 0))}
+                            y={Math.min(dimensions.height, Math.max(y, 0))}
                             cssColor={getPlayerColorCSS(playerIdx)}
                         />
                     );

--- a/src/examples/spaceshooter/renderer/EnemyLocation.tsx
+++ b/src/examples/spaceshooter/renderer/EnemyLocation.tsx
@@ -1,10 +1,26 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { getPlayerColorCSS } from '../../../gui/fixtures/player-colors';
 // import styles from './EndRoundLeaderBoard.module.css';
 import { PlayerInfo } from './PlayerHUD';
 import { WorldRef } from './ShooterRenderer';
 
-function Enemy({ x, y }: { x: number; y: number }) {
-    return <div style={{ position: 'absolute', left: x, bottom: y }}>👾</div>;
+function Enemy({ x, y, cssColor }: { x: number; y: number; cssColor: string }) {
+    const width = 10;
+    const height = 10;
+
+    return (
+        <div
+            style={{
+                position: 'absolute',
+                left: x - width / 2,
+                bottom: y - height / 2,
+                width: `${width}px`,
+                height: `${height}px`,
+                borderRadius: '50%',
+                backgroundColor: cssColor,
+            }}
+        ></div>
+    );
 }
 
 function getAngleRad(ax: number, ay: number, bx: number, by: number) {
@@ -73,7 +89,7 @@ export default function EnemyLocation({
 
     const centerX = dimensions.width / 2;
     const centerY = dimensions.height / 2;
-    const radius = 200; // Distance in px from the center
+    const radius = dimensions.height / 2;
 
     return (
         <div
@@ -82,10 +98,9 @@ export default function EnemyLocation({
                 position: 'absolute',
                 width: '100%',
                 height: '100%',
-                backgroundColor: 'rgba(255, 0, 0, 0.1)',
             }}
         >
-            {players.map((player) => {
+            {players.map((player, playerIdx) => {
                 if (player.id !== peerId) {
                     const enemyX =
                         worldRef.current.components.position.data.x[
@@ -102,21 +117,18 @@ export default function EnemyLocation({
                         radius,
                         angle,
                     );
+
                     return (
-                        <div key={player.id}>
-                            {player.id}
-                            <br />
-                            {`Angle: ${angle.toFixed(2)}°`}
-                            <Enemy x={x} y={y} />
-                        </div>
+                        <Enemy
+                            key={player.id}
+                            x={x}
+                            y={y}
+                            cssColor={getPlayerColorCSS(playerIdx)}
+                        />
                     );
+                } else {
+                    return null;
                 }
-                return (
-                    <div key={player.id}>
-                        {player.id} (you)
-                        <br />
-                    </div>
-                );
             })}
         </div>
     );

--- a/src/examples/spaceshooter/renderer/EnemyLocation.tsx
+++ b/src/examples/spaceshooter/renderer/EnemyLocation.tsx
@@ -1,26 +1,52 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Camera, Vector3 } from 'three';
 import { getPlayerColorCSS } from '../../../gui/fixtures/player-colors';
-// import styles from './EndRoundLeaderBoard.module.css';
 import { PlayerInfo } from './PlayerHUD';
 import { WorldRef } from './ShooterRenderer';
 
-function Enemy({ x, y, cssColor }: { x: number; y: number; cssColor: string }) {
-    const width = 10;
-    const height = 10;
+const INDICTOR_WIDTH = 20;
+const INDICTOR_HEIGHT = 20;
+
+function Enemy({
+    x,
+    y,
+    angle,
+    cssColor,
+}: {
+    x: number;
+    y: number;
+    angle: number;
+    cssColor: string;
+}) {
+    const adjustedAngle = angle - Math.PI / 2; // SVG points up
+    const angleDeg = adjustedAngle * (180 / Math.PI);
 
     return (
         <div
             style={{
                 position: 'absolute',
-                left: x - width / 2,
-                bottom: y - height / 2,
-                width: `${width}px`,
-                height: `${height}px`,
-                borderRadius: '50%',
-                backgroundColor: cssColor,
+                display: 'relative',
+                left: x,
+                bottom: y,
+                width: `${INDICTOR_WIDTH}px`,
+                height: `${INDICTOR_HEIGHT}px`,
             }}
-        ></div>
+        >
+            <svg
+                style={{
+                    width: '100%',
+                    height: '100%',
+                    top: 0,
+                    left: 0,
+                    position: 'absolute',
+                    transform: `rotate(${-angleDeg}deg)`,
+                }}
+                viewBox="0 0 700 700"
+                preserveAspectRatio="none"
+            >
+                <path d="M350,0 700,700 350,550 0,700" fill={cssColor} />
+            </svg>
+        </div>
     );
 }
 
@@ -133,7 +159,8 @@ export default function EnemyLocation({
                     const projectedPos = new Vector3(enemyX, enemyY, 0).project(
                         camera,
                     );
-                    // if in view
+
+                    // If in view don't show indicator
                     if (
                         projectedPos.x > -1 &&
                         projectedPos.x < 1 &&
@@ -154,8 +181,15 @@ export default function EnemyLocation({
                     return (
                         <Enemy
                             key={player.id}
-                            x={Math.min(dimensions.width, Math.max(x, 0))}
-                            y={Math.min(dimensions.height, Math.max(y, 0))}
+                            x={Math.min(
+                                dimensions.width - INDICTOR_WIDTH,
+                                Math.max(x, 0),
+                            )}
+                            y={Math.min(
+                                dimensions.height - INDICTOR_HEIGHT,
+                                Math.max(y, 0),
+                            )}
+                            angle={angle}
                             cssColor={getPlayerColorCSS(playerIdx)}
                         />
                     );

--- a/src/examples/spaceshooter/renderer/EnemyLocation.tsx
+++ b/src/examples/spaceshooter/renderer/EnemyLocation.tsx
@@ -7,49 +7,6 @@ import { WorldRef } from './ShooterRenderer';
 const INDICTOR_WIDTH = 20;
 const INDICTOR_HEIGHT = 20;
 
-function Enemy({
-    x,
-    y,
-    angle,
-    cssColor,
-}: {
-    x: number;
-    y: number;
-    angle: number;
-    cssColor: string;
-}) {
-    const adjustedAngle = angle - Math.PI / 2; // SVG points up
-    const angleDeg = adjustedAngle * (180 / Math.PI);
-
-    return (
-        <div
-            style={{
-                position: 'absolute',
-                display: 'relative',
-                left: x,
-                bottom: y,
-                width: `${INDICTOR_WIDTH}px`,
-                height: `${INDICTOR_HEIGHT}px`,
-            }}
-        >
-            <svg
-                style={{
-                    width: '100%',
-                    height: '100%',
-                    top: 0,
-                    left: 0,
-                    position: 'absolute',
-                    transform: `rotate(${-angleDeg}deg)`,
-                }}
-                viewBox="0 0 700 700"
-                preserveAspectRatio="none"
-            >
-                <path d="M350,0 700,700 350,550 0,700" fill={cssColor} />
-            </svg>
-        </div>
-    );
-}
-
 function getAngleRad(ax: number, ay: number, bx: number, by: number) {
     const dx = bx - ax;
     const dy = by - ay;
@@ -81,8 +38,11 @@ export default function EnemyLocation({
 }) {
     const componentRef = useRef<HTMLDivElement>(null);
     const currentRef = componentRef.current;
-    const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
-    const [hypotenuse, setHypotenuse] = useState(0);
+    const [viewDimensions, setViewDimensions] = useState({
+        width: 0,
+        height: 0,
+    });
+    const [viewDiagonal, setViewDiagonal] = useState(0);
 
     useEffect(() => {
         if (!currentRef) {
@@ -91,11 +51,11 @@ export default function EnemyLocation({
         // Function to update dimensions
         const updateDimensions = () => {
             if (componentRef.current) {
-                setDimensions({
+                setViewDimensions({
                     width: componentRef.current.offsetWidth,
                     height: componentRef.current.offsetHeight,
                 });
-                setHypotenuse(
+                setViewDiagonal(
                     Math.sqrt(
                         componentRef.current.offsetWidth ** 2 +
                             componentRef.current.offsetHeight ** 2,
@@ -119,9 +79,6 @@ export default function EnemyLocation({
         return null;
     }
 
-    // Memoize this?
-    // const playerShip = players.find((player) => player.id === peerId)?.ship;
-
     const playerShip = players.find((player) => player.id === peerId)?.ship;
     const playerX = playerShip
         ? worldRef.current.components.position.data.x[playerShip]
@@ -130,9 +87,9 @@ export default function EnemyLocation({
         ? worldRef.current.components.position.data.y[playerShip]
         : 0;
 
-    const centerX = dimensions.width / 2;
-    const centerY = dimensions.height / 2;
-    const radius = hypotenuse / 2;
+    const centerX = viewDimensions.width / 2;
+    const centerY = viewDimensions.height / 2;
+    const radius = viewDiagonal / 2;
 
     return (
         <div
@@ -182,11 +139,11 @@ export default function EnemyLocation({
                         <Enemy
                             key={player.id}
                             x={Math.min(
-                                dimensions.width - INDICTOR_WIDTH,
+                                viewDimensions.width - INDICTOR_WIDTH,
                                 Math.max(x, 0),
                             )}
                             y={Math.min(
-                                dimensions.height - INDICTOR_HEIGHT,
+                                viewDimensions.height - INDICTOR_HEIGHT,
                                 Math.max(y, 0),
                             )}
                             angle={angle}
@@ -197,6 +154,49 @@ export default function EnemyLocation({
                     return null;
                 }
             })}
+        </div>
+    );
+}
+
+function Enemy({
+    x,
+    y,
+    angle,
+    cssColor,
+}: {
+    x: number;
+    y: number;
+    angle: number;
+    cssColor: string;
+}) {
+    const adjustedAngle = angle - Math.PI / 2; // SVG points up
+    const angleDeg = adjustedAngle * (180 / Math.PI);
+
+    return (
+        <div
+            style={{
+                position: 'absolute',
+                display: 'relative',
+                left: x,
+                bottom: y,
+                width: `${INDICTOR_WIDTH}px`,
+                height: `${INDICTOR_HEIGHT}px`,
+            }}
+        >
+            <svg
+                style={{
+                    width: '100%',
+                    height: '100%',
+                    top: 0,
+                    left: 0,
+                    position: 'absolute',
+                    transform: `rotate(${-angleDeg}deg)`,
+                }}
+                viewBox="0 0 700 700"
+                preserveAspectRatio="none"
+            >
+                <path d="M350,0 700,700 350,550 0,700" fill={cssColor} />
+            </svg>
         </div>
     );
 }

--- a/src/examples/spaceshooter/renderer/PlayerCam.tsx
+++ b/src/examples/spaceshooter/renderer/PlayerCam.tsx
@@ -1,6 +1,7 @@
 import { PerspectiveCamera } from '@react-three/drei';
-import { useFrame } from '@react-three/fiber';
-import { memo } from 'react';
+import { useFrame, useThree } from '@react-three/fiber';
+import { memo, useEffect } from 'react';
+import { Camera } from 'three';
 import { DefaultMetrics } from '../../../runtime/metrics';
 import {
     EntityObject3D,
@@ -18,11 +19,19 @@ export default memo(function PlayerCam({
     worldRef,
     peerId,
     metrics,
+    setCamera,
 }: {
     worldRef: WorldRef;
     peerId: string;
     metrics?: DefaultMetrics;
+    setCamera: (camera: Camera) => void;
 }) {
+    const { camera } = useThree();
+
+    useEffect(() => {
+        setCamera(camera);
+    }, [camera, setCamera]);
+
     useFrame(({ camera }, deltaTime) => {
         // fps counter
         if (metrics) {
@@ -110,7 +119,7 @@ export default memo(function PlayerCam({
                 intensity={12}
                 color={0xffffff}
             />
-            
+
             <fog attach="fog" args={[0x444466, 100, 1]} />
             <BackgroundGrid />
         </>

--- a/src/examples/spaceshooter/renderer/PlayerHUD.tsx
+++ b/src/examples/spaceshooter/renderer/PlayerHUD.tsx
@@ -2,6 +2,7 @@ import { memo } from 'react';
 import { PlayerData } from '../../../runtime/ecs';
 import { ShooterSchema } from '../../spaceshooter';
 import Countdown from './Countdown';
+import EnemyLocation from './EnemyLocation';
 import EnergyBar from './EnergyBar';
 import LeaderBoard from './LeaderBoard';
 import { WorldRef } from './ShooterRenderer';
@@ -73,6 +74,11 @@ export default memo(function PlayerHUD({
                     <LeaderBoard players={players} peerId={peerId} />
                 </div>
             </div>
+            <EnemyLocation
+                players={players}
+                worldRef={worldRef}
+                peerId={peerId}
+            />
         </div>
     );
 });

--- a/src/examples/spaceshooter/renderer/PlayerHUD.tsx
+++ b/src/examples/spaceshooter/renderer/PlayerHUD.tsx
@@ -1,4 +1,5 @@
 import { memo } from 'react';
+import { Camera } from 'three';
 import { PlayerData } from '../../../runtime/ecs';
 import { ShooterSchema } from '../../spaceshooter';
 import Countdown from './Countdown';
@@ -18,11 +19,13 @@ export default memo(function PlayerHUD({
     players,
     tick,
     worldRef,
+    camera,
 }: {
     players: PlayerInfo[];
     peerId: string;
     tick: number;
     worldRef: WorldRef;
+    camera?: Camera;
 }) {
     const player = players.find((p) => p.id === peerId);
     if (!player) {
@@ -78,6 +81,7 @@ export default memo(function PlayerHUD({
                 players={players}
                 worldRef={worldRef}
                 peerId={peerId}
+                camera={camera}
             />
         </div>
     );

--- a/src/examples/spaceshooter/renderer/ShooterRenderer.tsx
+++ b/src/examples/spaceshooter/renderer/ShooterRenderer.tsx
@@ -1,6 +1,7 @@
 import { PositionalAudio, useGLTF } from '@react-three/drei';
 import { Canvas } from '@react-three/fiber';
 import { memo, useEffect, useMemo, useRef, useState } from 'react';
+import { Camera } from 'three';
 import { EntityId, World } from '../../../runtime/ecs';
 import { RendererProps } from '../../../runtime/game';
 import { ModelType, ShooterSchema } from '../../spaceshooter';
@@ -40,6 +41,7 @@ export default memo(function ShooterCanvas({
     const [nextPlayers, setNextPlayers] = useState<PlayerInfo[]>([]);
     const prevPlayers = useRef<PlayerInfo[]>([]);
     const [tick, setTick] = useState(0);
+    const [camera, setCamera] = useState<Camera>();
 
     // subscribe to updates
     useEffect(() => {
@@ -116,6 +118,7 @@ export default memo(function ShooterCanvas({
                     peerId={peerId}
                     worldRef={worldRef}
                     metrics={metrics}
+                    setCamera={setCamera}
                 />
                 <PositionalAudio
                     autoplay={true}
@@ -130,6 +133,7 @@ export default memo(function ShooterCanvas({
                 players={nextPlayers}
                 tick={tick}
                 worldRef={worldRef}
+                camera={camera}
             />
         </>
     );


### PR DESCRIPTION
# What

<img width="1275" alt="image" src="https://github.com/user-attachments/assets/be42ca0b-9312-4079-ada5-0d4dfc2520f0">

Showing arrows at the edge of the screen pointing in the direction of the enemy. When the enemy is on screen the arrow will disappear

# Why

So we can find ships to shoot

# How

I'm rendering these arrows as standard svg elements. To know if an enemy is on screen I needed to have a reference to the three.js camera to test if a point in world space is visible in view space. Seeing as we are rendering the HUD using html elements I thought these indicators as SVGs would be o.k but if it kills performance we could either render canvas or use three and render to an orthographic camera (maybe a bit much for this task?)

fixes: #38