### PR TITLE
confirmations out of sync

### DIFF
--- a/src/runtime/client.ts
+++ b/src/runtime/client.ts
@@ -421,9 +421,7 @@ export class Client {
                     await Promise.all(
                         ackee.acks.map(
                             (ackAckId) =>
-                                this.updateMessageConfirmations(
-                                    Buffer.from(ackAckId, 'base64'),
-                                ),
+                                this.updateMessageConfirmations(ackAckId),
                             [] as Promise<StoredMessage>[],
                         ),
                     );
@@ -440,9 +438,6 @@ export class Client {
             return null;
         }
         const confirmations = await this.calculateMessageConfirmations(id);
-        if (ackee.confirmations.join(',') === confirmations.join(',')) {
-            return ackee;
-        }
         const updated: StoredMessage = {
             ...ackee,
             updated: this.nextSequenceNumber(),

--- a/src/runtime/simulation.ts
+++ b/src/runtime/simulation.ts
@@ -184,6 +184,8 @@ export class Simulation {
                     startFromRound = m.round - 1;
                 }
             });
+        // always fetch enough to recalculate the wave
+        startFromRound = Math.max(startFromRound - this.interlace * 4, 1); // THINK: can we reduce num of fetched wave msgs
         // find the closest state to satisfy startFromRound
         // if we're already at the round we need, return it
         if (latestState.round === startFromRound) {
@@ -333,7 +335,7 @@ export class Simulation {
             // we need to check if the message is accepted or rejected
             const offsetFromFinalization = latestRound - m.round;
             const needsFinalization =
-                offsetFromFinalization > this.interlace * 3 + 2;
+                offsetFromFinalization > this.interlace * 3;
             let accepted = true;
             // is well acked?
             // TODO: reduce this number to supermajority


### PR DESCRIPTION
## what

* fix incorrect parsing of ackid as uint8array
* do not skip setting update when confirmations unchanged

## why

in #41 we had to switch a bunch of ids from uint8arrays to stringified values ... one of them got missed, which meant confirmations would not get updated correctly.

fixes: #39 

## note for testing

tricky on to test since it doesn't happen always, so not 100% sure if this is the fix or not

the desync issue would only surfice when (1) there is some packet loss/laggy players AND (2) you are playing with at least 3 players.

so if testing on own, you will need to spin up 3 windows and probably enable poor network conditions (like via the Network Link Conditioner in macos) .... OR .... play with some real people 