### PR TITLE
remove useFrame from starfield effect

### DIFF
--- a/src/examples/spaceshooter/effects/FXStarfieldQuarks.ts
+++ b/src/examples/spaceshooter/effects/FXStarfieldQuarks.ts
@@ -6,14 +6,9 @@ import { Object3D } from "three";
 
 // Define the type for the methods you will expose via ref
 
-  export const StarFieldFX =((props, ref) => {
+  export const StarFieldFX =(() => {
     const [batchRenderer] = useState(new BatchedRenderer());
-    const [effect, setEffect] = useState(new Object3D());
     const { scene } = useThree();
-  
-    useFrame((state, delta) => {
-      batchRenderer.update(delta);
-    });
   
     useEffect(() => {
       const loader = new QuarksLoader();
@@ -21,8 +16,8 @@ import { Object3D } from "three";
       loader.parse([explodeJson][0], (obj) => {
         QuarksUtil.addToBatchRenderer(obj, batchRenderer);
         obj.position.set(0, 0, -130);
-        setEffect(obj);
-        scene.add(obj);
+          batchRenderer.update(2000);
+          scene.add(obj);
       });
       scene.add(batchRenderer);
   

--- a/src/examples/spaceshooter/effects/FXStarfieldQuarks.ts
+++ b/src/examples/spaceshooter/effects/FXStarfieldQuarks.ts
@@ -7,10 +7,10 @@ import { Object3D } from "three";
 // Define the type for the methods you will expose via ref
 
   export const StarFieldFX =(() => {
-    const [batchRenderer] = useState(new BatchedRenderer());
     const { scene } = useThree();
   
-    useEffect(() => {
+      useEffect(() => {
+        const batchRenderer = new BatchedRenderer();
       const loader = new QuarksLoader();
       loader.setCrossOrigin('');
       loader.parse([explodeJson][0], (obj) => {
@@ -24,7 +24,7 @@ import { Object3D } from "three";
       return () => {
         scene.remove(batchRenderer);
       };
-    }, [batchRenderer, scene]);
+    }, [scene]);
   
     return null;
   });


### PR DESCRIPTION
This PR removes the useFrame hook on the starfield effect which updates the effect's batchRenderer.
The starfield effect doesn't really need to be update once it's loaded in, so instead I update it once (with 2 seconds into the effect's lifetime) and then just leave it.