### PR TITLE
Unparented explosion from ship

### DIFF
--- a/src/diorama.tsx
+++ b/src/diorama.tsx
@@ -168,10 +168,7 @@ function Particles(props: { bufferScene: Scene }) {
         function onDocumentKeyUp(event: KeyboardEvent) {
             const keyCode = event.which;
             if (keyCode === 49) {
-                explosionRef.current.triggerExplosion(
-                    new Vector3(40, 0, 0),
-                    scene,
-                );
+                explosionRef.current.triggerExplosion(new Vector3(40, 0, 0));
             }
             if (keyCode === 50) {
                 respawnRef.current.triggerSpawn(new Vector3(40, 0, 0), scene);
@@ -320,7 +317,6 @@ function Diorama() {
                 color={0xffffff}
             />
 
-            <fog attach="fog" args={[0x444466, 100, 1]} />
             {/* <BackgroundGrid /> */}
             <Particles
                 bufferScene={RENDER_BUFFER_SCENE ? scene : bufferScene}

--- a/src/examples/spaceshooter/effects/FXExplodeQuarks.ts
+++ b/src/examples/spaceshooter/effects/FXExplodeQuarks.ts
@@ -7,7 +7,7 @@ import { addShake } from "../renderer/ShakeManager";
 
 // Define the type for the methods you will expose via ref
 export interface ExplodeFXHandle {
-    triggerExplosion: (pos:Vector3, parent:Object3D) => void;
+    triggerExplosion: (pos:Vector3) => void;
   }
   
   export const ExplodeFX = forwardRef<ExplodeFXHandle>((props, ref) => {
@@ -16,8 +16,7 @@ export interface ExplodeFXHandle {
     const { scene } = useThree();
   
     useImperativeHandle(ref, () => ({
-      triggerExplosion(pos: Vector3, parent: Object3D) {
-            parent.add(effect);
+      triggerExplosion(pos: Vector3) {
             effect.position.copy(pos);
             QuarksUtil.restart(effect);
             addShake({

--- a/src/examples/spaceshooter/renderer/PlayerCam.tsx
+++ b/src/examples/spaceshooter/renderer/PlayerCam.tsx
@@ -1,6 +1,6 @@
 import { PerspectiveCamera } from '@react-three/drei';
 import { useFrame, useThree } from '@react-three/fiber';
-import { memo, useRef, useEffect } from 'react';
+import { memo, useEffect, useRef } from 'react';
 import { Camera, Vector3 } from 'three';
 import { DefaultMetrics } from '../../../runtime/metrics';
 import {
@@ -124,8 +124,6 @@ export default memo(function PlayerCam({
                 intensity={12}
                 color={0xffffff}
             />
-
-            <fog attach="fog" args={[0x444466, 100, 1]} />
             {/* <BackgroundGrid /> */}
         </>
     );

--- a/src/examples/spaceshooter/renderer/ShipEntity.tsx
+++ b/src/examples/spaceshooter/renderer/ShipEntity.tsx
@@ -211,9 +211,9 @@ export default memo(function ShipEntity({
         if (explosionRef.current) {
             const exploding = prevHealthRef.current > 0 && health <= 0;
             if (exploding) {
-                const pos = new Vector3(0, 0, 0);
+                const pos = groupRef.current.position.clone();
                 if (explosionRef.current) {
-                    explosionRef.current.triggerExplosion(pos, shipRef.current);
+                    explosionRef.current.triggerExplosion(pos);
                 }
                 // make noise too
                 if (!explosionSfxRef.current.isPlaying) {


### PR DESCRIPTION
This PR fixes a bug with the explosion effect which meant it travelled with the affected ship after it respawns, and then gets dragged around with it until the effect ended.