### PR TITLE
Connectivity Widget

### DIFF
--- a/src/gui/components/ChannelView.tsx
+++ b/src/gui/components/ChannelView.tsx
@@ -14,6 +14,7 @@ import { useSettings } from '../hooks/use-settings';
 import SimulationProvider from '../providers/SimulationProvider';
 import theme from '../styles/default.module.css';
 import { TERM_DELAY } from './ChannelBoot';
+import Connectivity from './Connectivity';
 import PacketLace from './PacketLace';
 import Renderer from './Renderer';
 import { Spinner } from './Spinner';
@@ -439,6 +440,10 @@ export default memo(function ChannelView({
                     >
                         {muted ? 'volume_off' : 'volume_up'}
                     </span>
+                    <Connectivity
+                        metric={metrics.cps}
+                        peerCount={channel.peers.length}
+                    />
                 </div>
             </div>
             {details && (

--- a/src/gui/components/Connectivity.tsx
+++ b/src/gui/components/Connectivity.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { Metric } from '../../runtime/metrics';
 import theme from '../styles/default.module.css';
 
-const SHOW_AT_THRESHOLD = 5;
+const SHOW_AT_THRESHOLD = 6;
 
 export default function Connectivity({
     metric,
@@ -12,8 +12,9 @@ export default function Connectivity({
     peerCount: number;
 }) {
     const [state, setState] = useState({
-        showConnectivity: true,
+        showConnectivity: false,
         color: '#fac905',
+        icon: 'sentiment_dissatisfied',
     });
 
     useEffect(() => {
@@ -21,6 +22,10 @@ export default function Connectivity({
             setState({
                 showConnectivity: value <= SHOW_AT_THRESHOLD && peerCount > 0,
                 color: value < 1 ? '#FF0000' : '#fac905',
+                icon:
+                    value < 1
+                        ? 'sentiment_very_dissatisfied'
+                        : 'sentiment_dissatisfied',
             });
         });
     }, [metric, peerCount]);
@@ -28,17 +33,33 @@ export default function Connectivity({
     return (
         <>
             {state.showConnectivity && (
-                <span
+                <div
                     style={{
                         position: 'absolute',
                         top: '1rem',
                         left: '1rem',
+                        display: 'flex',
+                        alignItems: 'center',
                         color: state.color,
                     }}
-                    className={theme.materialSymbolsOutlined}
                 >
-                    link
-                </span>
+                    <span
+                        style={{
+                            fontSize: '2rem',
+                        }}
+                        className={theme.materialSymbolsOutlined}
+                    >
+                        {state.icon}
+                    </span>
+                    <span
+                        style={{
+                            color: 'white',
+                            marginLeft: '0.5rem',
+                        }}
+                    >
+                        connection issue
+                    </span>
+                </div>
             )}
         </>
     );

--- a/src/gui/components/Connectivity.tsx
+++ b/src/gui/components/Connectivity.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import { Metric } from '../../runtime/metrics';
+import theme from '../styles/default.module.css';
+
+const SHOW_AT_THRESHOLD = 5;
+
+export default function Connectivity({
+    metric,
+    peerCount,
+}: {
+    metric: Metric;
+    peerCount: number;
+}) {
+    const [state, setState] = useState({
+        showConnectivity: true,
+        color: '#fac905',
+    });
+
+    useEffect(() => {
+        metric.subscribe((value) => {
+            setState({
+                showConnectivity: value <= SHOW_AT_THRESHOLD && peerCount > 0,
+                color: value < 1 ? '#FF0000' : '#fac905',
+            });
+        });
+    }, [metric, peerCount]);
+
+    return (
+        <>
+            {state.showConnectivity && (
+                <span
+                    style={{
+                        position: 'absolute',
+                        top: '1rem',
+                        left: '1rem',
+                        color: state.color,
+                    }}
+                    className={theme.materialSymbolsOutlined}
+                >
+                    link
+                </span>
+            )}
+        </>
+    );
+}


### PR DESCRIPTION
## What

- Shows connectivity chain when cps is <= 5
  - Orange when `cps` <= 5
  - Red when < 1

![image](https://github.com/user-attachments/assets/350cc699-d28d-457b-9b27-1e884c60fadc)

## Why

In cases where the player is unable to move because commits per second is 0, or extremely low, we want an on-screen indicator to inform them of this.

## Notes
The easiest way I've found to solo test this is to move a window to another monitor and `cps` should drop to 0 momentarily

Resolves: #119 