### PR TITLE
reducing CPU usage, re-renders, and message processing contention

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -386,7 +386,7 @@ declare module "socket:events" {
         prependOnceListener(type: any, listener: any): this;
         removeListener(type: any, listener: any): this;
         off(type: any, listener: any): this;
-        removeAllListeners(type: any, ...args: any[]): this;
+        removeAllListeners(type?: any, ...args?: any[]): this;
         listeners(type: any): any[];
         rawListeners(type: any): any[];
         listenerCount(type: any): any;
@@ -9486,7 +9486,7 @@ declare module "socket:dgram" {
          * @param {function} callback - With no parameters. Called when binding is complete.
          * @see {@link https://nodejs.org/api/dgram.html#socketbindport-address-callback}
          */
-        bind(arg1: any, arg2: any, arg3: any): this;
+        bind(arg1?: any, arg2?: any, arg3?: any): this;
         dataListener: ({ detail }: {
             detail: any;
         }) => any;
@@ -9572,7 +9572,7 @@ declare module "socket:dgram" {
          *
          * @see {@link https://nodejs.org/api/dgram.html#socketclosecallback}
          */
-        close(cb: any): this;
+        close(cb?: any): this;
         /**
          *
          * Returns an object containing the address information for a socket. For

--- a/src/examples/spaceshooter/effects/ParticleAssets.ts
+++ b/src/examples/spaceshooter/effects/ParticleAssets.ts
@@ -44,8 +44,6 @@ export class ParticleAssets {
     }
 
     async loadParticles() {
-        console.log('loading particle effects');
-
         await Promise.all(
             this.particleCollection.particleAssets.flatMap((asset) =>
                 asset.effect.particleSystems.map((s) => s.prepare()),

--- a/src/examples/spaceshooter/renderer/BackgroundModels.tsx
+++ b/src/examples/spaceshooter/renderer/BackgroundModels.tsx
@@ -1,6 +1,6 @@
 import { useGLTF } from '@react-three/drei';
-import React, { useMemo } from 'react';
-import { MeshBasicMaterial } from 'three';
+import { useMemo } from 'react';
+import { Mesh, MeshBasicMaterial } from 'three';
 import shipGLTF from '../assets/BaackgroundElements/BaackgroundElements.glb?url';
 import { assetPath } from '../utils/RenderUtils';
 
@@ -12,7 +12,7 @@ export function BackgroundModels(props) {
     // Preprocess the scene only once
     const processedScene = useMemo(() => {
         gltf.scene.traverse((child) => {
-            if (child.isMesh) {
+            if (child instanceof Mesh) {
                 // Set flags that won't change
                 child.castShadow = false;
                 child.receiveShadow = false;
@@ -24,7 +24,9 @@ export function BackgroundModels(props) {
                 });
 
                 targetMaterial.transparent = true;
-                targetMaterial.map.needsUpdate = true;
+                if (targetMaterial.map) {
+                    targetMaterial.map.needsUpdate = true;
+                }
                 child.material = targetMaterial;
 
                 // Set additional material properties

--- a/src/examples/spaceshooter/renderer/BulletEntity.tsx
+++ b/src/examples/spaceshooter/renderer/BulletEntity.tsx
@@ -51,7 +51,11 @@ export default memo(function BulletEntity({
         const isNewlySpawned =
             world.components.stats.data.health[eid] > BULLET_LIFETIME - 1;
 
-        interpolateEntityVisibility(bullet, world, eid, 0);
+        if (isNewlySpawned) {
+            bullet.visible = false;
+        } else {
+            interpolateEntityVisibility(bullet, world, eid, 0);
+        }
 
         // track bullet
         interpolateEntityPosition(

--- a/src/examples/spaceshooter/renderer/BulletEntity.tsx
+++ b/src/examples/spaceshooter/renderer/BulletEntity.tsx
@@ -1,10 +1,8 @@
-import { Clone, PositionalAudio, useGLTF } from '@react-three/drei';
+import { Clone, PositionalAudio } from '@react-three/drei';
 import { useFrame } from '@react-three/fiber';
-import { memo, useMemo, useRef } from 'react';
+import { memo, useRef } from 'react';
 import {
-    AdditiveBlending,
     Group,
-    Mesh,
     Object3DEventMap,
     PositionalAudio as PositionalAudioImpl,
     Vector3,
@@ -12,7 +10,6 @@ import {
 import { Tags } from '../../spaceshooter';
 import sfxHit from '../assets/Hit.mp3?url';
 import sfxShot from '../assets/Shot.mp3?url';
-import shipGLTF from '../assets/bullet.glb?url';
 import {
     ShipImpactFX,
     ShipImpactFXHandle,
@@ -20,7 +17,6 @@ import {
 import { BULLET_LIFETIME } from '../systems/bulletSystem';
 import {
     EntityObject3D,
-    InterpolateMethod,
     InterpolateSpeed,
     assetPath,
     interpolateEntityPosition,

--- a/src/examples/spaceshooter/renderer/BulletEntity.tsx
+++ b/src/examples/spaceshooter/renderer/BulletEntity.tsx
@@ -52,14 +52,10 @@ export default memo(function BulletEntity({
         // during the first few frames of bullet shooting, the bullet is not
         // alighed with the interpolated position of the ship so we hide it for
         // a bit and snap position to make it look bit better
-        const isNewlySpawned =         
+        const isNewlySpawned =
             world.components.stats.data.health[eid] > BULLET_LIFETIME - 1;
-        
-       // if (isNewlySpawned) {
-            //bullet.visible = false;
-        //} else
-            interpolateEntityVisibility(bullet, world, eid, 0);
-        //}
+
+        interpolateEntityVisibility(bullet, world, eid, 0);
 
         // track bullet
         interpolateEntityPosition(
@@ -67,7 +63,7 @@ export default memo(function BulletEntity({
             world,
             eid,
             deltaTime,
-            isNewlySpawned ? InterpolateSpeed.Quick : InterpolateSpeed.Fastest,
+            isNewlySpawned ? InterpolateSpeed.Snap : InterpolateSpeed.Fastest,
         );
         interpolateEntityRotation(
             group,

--- a/src/examples/spaceshooter/renderer/BulletModel.tsx
+++ b/src/examples/spaceshooter/renderer/BulletModel.tsx
@@ -1,6 +1,6 @@
 import { useGLTF } from '@react-three/drei';
 import { useMemo } from 'react';
-import { AdditiveBlending, Mesh, MeshBasicMaterial } from 'three';
+import { Mesh, MeshBasicMaterial } from 'three';
 import shipGLTF from '../assets/bullet.glb?url';
 import { assetPath } from '../utils/RenderUtils';
 
@@ -15,7 +15,9 @@ export default function BulletModel() {
                 });
 
                 targetMaterial.transparent = true;
-                targetMaterial.map.needsUpdate = true;
+                if (targetMaterial.map) {
+                    targetMaterial.map.needsUpdate = true;
+                }
                 child.material = targetMaterial;
             }
         });

--- a/src/examples/spaceshooter/renderer/LeaderBoard.tsx
+++ b/src/examples/spaceshooter/renderer/LeaderBoard.tsx
@@ -1,17 +1,19 @@
+import { memo } from 'react';
 import { getPlayerColorCSS } from '../../../gui/fixtures/player-colors';
 import styles from './LeaderBoard.module.css';
 import { PlayerInfo } from './PlayerHUD';
 
-export interface Score {
+export type Score = {
+    id: string;
     user: string;
     score: number;
     color: string;
     animClass?: string;
     isMe?: boolean;
     lastPosition?: number;
-}
+};
 
-export default function LeaderBoard({
+export default memo(function LeaderBoard({
     players,
     peerId,
 }: {
@@ -20,6 +22,7 @@ export default function LeaderBoard({
 }) {
     const scores: Score[] = players
         .map((p) => ({
+            id: p.id,
             user: p.name,
             score: p.score,
             color: getPlayerColorCSS(players.findIndex((pp) => pp.id === p.id)), //'#ac75eb',
@@ -55,49 +58,21 @@ export default function LeaderBoard({
         score.lastPosition = index;
     });
 
-    let leaders: Score[];
-    let meScoreIndex = -1;
-
-    if (isMeInTop) {
-        leaders = scores.slice(0, 4);
-    } else {
-        const meScore = scores.find((score, index) => {
-            if (score.isMe) {
-                meScoreIndex = index;
-                return true;
-            }
-            return false;
-        });
-        if (meScore) {
-            leaders = [...topThree, meScore];
-        } else {
-            leaders = topThree;
-        }
-    }
-
-    const scoresBetween = meScoreIndex > 3 ? meScoreIndex - 3 : 0;
-
     return (
         <div className={styles.leaderboard}>
-            {leaders.map((leader, index) => (
+            {scores.slice(0, 4).map((leader, index) => (
                 <LdrEntry
-                    key={index + '-' + leader.user + '-' + leader.score}
+                    key={leader.id}
                     userScore={leader}
-                    position={
-                        scores.findIndex(
-                            (score) => score.user === leader.user,
-                        ) + 1
-                    }
-                    scoresBetween={
-                        !isMeInTop && index === 3 ? scoresBetween : 0
-                    }
+                    position={index + 1}
+                    scoresBetween={0}
                 />
             ))}
         </div>
     );
-}
+});
 
-function LdrEntry(props: {
+const LdrEntry = memo(function LdrEntry(props: {
     userScore: Score;
     position: number;
     scoresBetween?: number;
@@ -128,27 +103,4 @@ function LdrEntry(props: {
             </div>
         </>
     );
-}
-
-export function shadeColor(color: string, percent: number) {
-    let R = parseInt(color.substring(1, 3), 16);
-    let G = parseInt(color.substring(3, 5), 16);
-    let B = parseInt(color.substring(5, 7), 16);
-
-    R = Math.floor((R * (100 + percent)) / 100);
-    G = Math.floor((G * (100 + percent)) / 100);
-    B = Math.floor((B * (100 + percent)) / 100);
-
-    R = R < 255 ? R : 255;
-    G = G < 255 ? G : 255;
-    B = B < 255 ? B : 255;
-
-    const RR =
-        R.toString(16).length === 1 ? '0' + R.toString(16) : R.toString(16);
-    const GG =
-        G.toString(16).length === 1 ? '0' + G.toString(16) : G.toString(16);
-    const BB =
-        B.toString(16).length === 1 ? '0' + B.toString(16) : B.toString(16);
-
-    return '#' + RR + GG + BB;
-}
+});

--- a/src/examples/spaceshooter/renderer/ModelEntity.tsx
+++ b/src/examples/spaceshooter/renderer/ModelEntity.tsx
@@ -15,7 +15,6 @@ export const ModelEntity = memo(function ModelEntity({
     playersRef: PlayersRef;
     peerId: string;
 }) {
-    console.log('ModelEntity', eid);
     switch (worldRef.current.components.model.data.type[eid]) {
         case ModelType.Ship:
             return (

--- a/src/examples/spaceshooter/renderer/PlayerCam.tsx
+++ b/src/examples/spaceshooter/renderer/PlayerCam.tsx
@@ -60,7 +60,7 @@ export default memo(function PlayerCam({
         const snapiness =
             world.components.entity.data.generation[player.ship] ===
             (camera as EntityObject3D).__generation
-                ? InterpolateSpeed.Quick * 1.5
+                ? InterpolateSpeed.Quick
                 : InterpolateSpeed.Snap;
         camera.position.x = Math.max(
             Math.min(
@@ -95,7 +95,7 @@ export default memo(function PlayerCam({
                 world.components.velocity.data.y[player.ship] *
                     world.components.velocity.data.y[player.ship],
         );
-        const zoom = CAM_INITIAL_ZOOM + vmag ;
+        const zoom = CAM_INITIAL_ZOOM + vmag;
         camera.position.z = interpolate(
             camera.position.z,
             zoom,

--- a/src/examples/spaceshooter/renderer/PlayerHUD.tsx
+++ b/src/examples/spaceshooter/renderer/PlayerHUD.tsx
@@ -39,7 +39,7 @@ export default memo(function PlayerHUD({
                 remainingTicks * (FIXED_UPDATE_RATE / 1000);
             // format as MM:SS with leading zeros
             setRemaining(remainingSeconds);
-        }, 500);
+        }, 1000);
         return () => clearInterval(timer);
     }, [worldRef]);
 

--- a/src/examples/spaceshooter/renderer/PlayerHUD.tsx
+++ b/src/examples/spaceshooter/renderer/PlayerHUD.tsx
@@ -39,7 +39,7 @@ export default memo(function PlayerHUD({
                 remainingTicks * (FIXED_UPDATE_RATE / 1000);
             // format as MM:SS with leading zeros
             setRemaining(remainingSeconds);
-        }, 1000);
+        }, 500);
         return () => clearInterval(timer);
     }, [worldRef]);
 

--- a/src/examples/spaceshooter/renderer/ShipEntity.tsx
+++ b/src/examples/spaceshooter/renderer/ShipEntity.tsx
@@ -115,7 +115,7 @@ export default memo(function ShipEntity({
             world,
             eid,
             deltaTime,
-            InterpolateSpeed.Quick * 2,
+            InterpolateSpeed.Fastest,
         );
         const rotationBefore = ship.rotation.z;
         interpolateEntityRotation(
@@ -181,8 +181,6 @@ export default memo(function ShipEntity({
             InterpolateSpeed.Quick,
         );
 
-
-        
         // flash ship if we lost health
         const health = world.components.stats.data.health[eid];
         if (
@@ -219,7 +217,6 @@ export default memo(function ShipEntity({
             }
         });
         */
-        
 
         // create wall sparks
         const hit = world.components.collider.data.hasCollided[eid];

--- a/src/examples/spaceshooter/renderer/ShooterRenderer.tsx
+++ b/src/examples/spaceshooter/renderer/ShooterRenderer.tsx
@@ -39,7 +39,6 @@ export default memo(function ShooterCanvas({
     const prevEntities = useRef<(EntityId | null)[]>([]);
 
     // stuff we send to the hud
-    const [nextPlayers, setNextPlayers] = useState<PlayerInfo[]>([]);
     const prevPlayers = useRef<PlayerInfo[]>([]);
 
     // subscribe to updates
@@ -80,7 +79,6 @@ export default memo(function ShooterCanvas({
                     );
                 })
             ) {
-                setNextPlayers(nextPlayers);
                 playersRef.current = nextPlayers;
             }
             prevPlayers.current = nextPlayers;
@@ -131,8 +129,9 @@ export default memo(function ShooterCanvas({
             </Canvas>
             <PlayerHUD
                 peerId={peerId}
-                players={nextPlayers}
+                playersRef={playersRef}
                 worldRef={worldRef}
+                metrics={metrics}
             />
         </>
     );

--- a/src/examples/spaceshooter/systems/bulletSystem.ts
+++ b/src/examples/spaceshooter/systems/bulletSystem.ts
@@ -12,7 +12,7 @@ export const BULLET_MAX_VELOCITY = 110;
 export const BULLET_LIFETIME = 26;
 export const SHIP_SHOOT_COOLOFF = 2;
 export const BULLET_HEALTH_COST = 14;
-export const BULLET_INHERIT_VELOCITY = 0.5 ; //What % velocity do they inherit from firing ship
+export const BULLET_INHERIT_VELOCITY = 1; //What % velocity do they inherit from firing ship
 
 export default system<ShooterSchema>(
     ({
@@ -58,10 +58,9 @@ export default system<ShooterSchema>(
                 entity.active[bullet] = 0;
             }
             //Destroy bullets when parent ship dies
-            else if (stats.health[entity.parent[bullet]] === 0)    {
+            else if (stats.health[entity.parent[bullet]] === 0) {
                 entity.active[bullet] = 0;
-            }
-            else {
+            } else {
                 stats.health[bullet] = Math.max(
                     Math.fround(stats.health[bullet] - deltaTime),
                     0,
@@ -109,19 +108,23 @@ export default system<ShooterSchema>(
                 }
                 stats.health[player.ship] -= BULLET_HEALTH_COST;
                 stats.shootTimer[player.ship] = SHIP_SHOOT_COOLOFF;
-                
+
                 const offsetAmount = 3;
 
-                position.x[bullet] = position.x[player.ship] + (offsetAmount * Math.cos(rotation.z[player.ship]));
-                position.y[bullet] = position.y[player.ship] + (offsetAmount * Math.sin(rotation.z[player.ship]));
+                position.x[bullet] =
+                    position.x[player.ship] +
+                    offsetAmount * Math.cos(rotation.z[player.ship]);
+                position.y[bullet] =
+                    position.y[player.ship] +
+                    offsetAmount * Math.sin(rotation.z[player.ship]);
                 rotation.z[bullet] = rotation.z[player.ship];
 
                 velocity.x[bullet] = Math.fround(
-                    (velocity.x[player.ship] * BULLET_INHERIT_VELOCITY)+
+                    velocity.x[player.ship] * BULLET_INHERIT_VELOCITY +
                         Math.cos(rotation.z[player.ship]) * BULLET_SPEED,
                 );
                 velocity.y[bullet] = Math.fround(
-                    (velocity.y[player.ship] * BULLET_INHERIT_VELOCITY) +
+                    velocity.y[player.ship] * BULLET_INHERIT_VELOCITY +
                         Math.sin(rotation.z[player.ship]) * BULLET_SPEED,
                 );
 

--- a/src/examples/spaceshooter/systems/levelSystem.ts
+++ b/src/examples/spaceshooter/systems/levelSystem.ts
@@ -83,7 +83,7 @@ function addWall(
     const rect = convertToRectangle(
         wall.position.x,
         wall.position.y,
-        wall.width,
+        wall.width + 1,
         level.wallColliderWidth,
         wall.rotation,
     );

--- a/src/examples/spaceshooter/systems/physicsSystem.ts
+++ b/src/examples/spaceshooter/systems/physicsSystem.ts
@@ -25,12 +25,14 @@ export default system<ShooterSchema>(
         deltaTime,
     }) => {
         const bodies = query(Tags.IsSolidBody);
-        const steps = Math.ceil(100 * deltaTime); // number of times we check physics between updates
-        // console.log('steps', steps);
+        const shipsAndBullets = bodies.filter(
+            (eid) => hasTag(eid, Tags.IsShip) || hasTag(eid, Tags.IsBullet),
+        );
+        const steps = 1; // number of times we check physics between updates
 
         // apply physics
         for (let i = 0; i < steps; i++) {
-            for (const eid of bodies) {
+            for (const eid of shipsAndBullets) {
                 if (i === 0) {
                     collider.hasCollided[eid] = 0; // reset collision flag
                     collider.collisionEntity[eid] = 0; // reset collision flag

--- a/src/examples/spaceshooter/systems/physicsSystem.ts
+++ b/src/examples/spaceshooter/systems/physicsSystem.ts
@@ -28,7 +28,7 @@ export default system<ShooterSchema>(
         const otherBodies = bodies.filter(
             (eid) => !hasTag(eid, Tags.IsBullet) && entity.active[eid],
         );
-        const steps = 2; // number of times we check physics between updates
+        const steps = 1; // number of times we check physics between updates
 
         // apply physics
         for (let i = 0; i < steps; i++) {

--- a/src/examples/spaceshooter/systems/physicsSystem.ts
+++ b/src/examples/spaceshooter/systems/physicsSystem.ts
@@ -51,12 +51,10 @@ export default system<ShooterSchema>(
 
                 // set position based on velocity
                 position.x[eid] = Math.fround(
-                    position.x[eid] +
-                        (velocity.x[eid] * deltaTime) / (steps + 0.05),
+                    position.x[eid] + (velocity.x[eid] * deltaTime) / steps,
                 );
                 position.y[eid] = Math.fround(
-                    position.y[eid] +
-                        (velocity.y[eid] * deltaTime) / (steps + 0.05),
+                    position.y[eid] + (velocity.y[eid] * deltaTime) / steps,
                 );
                 const velocityMagnitude = Math.sqrt(
                     velocity.x[eid] ** 2 + velocity.y[eid] ** 2,
@@ -165,6 +163,20 @@ function collideCircle(
         },
         radius: collider.radius[thatEid],
     };
+
+    // cull out early if we can
+    if (
+        Math.abs(circle1.center.x - circle2.center.x) >
+        circle1.radius + circle2.radius
+    ) {
+        return;
+    }
+    if (
+        Math.abs(circle1.center.y - circle2.center.y) >
+        circle1.radius + circle2.radius
+    ) {
+        return;
+    }
 
     const distance = Math.sqrt(
         (circle1.center.x - circle2.center.x) ** 2 +

--- a/src/examples/spaceshooter/systems/shipSystem.ts
+++ b/src/examples/spaceshooter/systems/shipSystem.ts
@@ -142,7 +142,7 @@ function addShip({
     // stats.canShoot[eid] = 1;
     position.x[eid] = eid / 100;
     collider.type[eid] = ColliderType.Circle;
-    collider.radius[eid] = 5;
+    collider.radius[eid] = 3.5;
     physics.applyRotation[eid] = 0;
     physics.drag[eid] = 0.01;
     physics.bounciness[eid] = SHIP_BOUNCINESS;
@@ -198,7 +198,7 @@ function addBullet(
     model.type[eid] = ModelType.Bullet;
     entity.active[eid] = 0;
     collider.type[eid] = ColliderType.Circle;
-    collider.radius[eid] = 0.7;
+    collider.radius[eid] = 0.8;
     physics.applyRotation[eid] = 1;
     physics.drag[eid] = 0;
     physics.isTrigger[eid] = 1;

--- a/src/examples/spaceshooter/systems/shipSystem.ts
+++ b/src/examples/spaceshooter/systems/shipSystem.ts
@@ -12,7 +12,7 @@ import {
 import level from '../levels/level_1';
 
 export const SHIP_THRUST_RATE = 60;
-export const SHIP_ROTATION_RATE = Math.fround(Math.PI / 0.6); //was 0.7
+export const SHIP_ROTATION_RATE = Math.fround(Math.PI / 0.7);
 export const SHIP_RESPAWN_RADIUS = level.spawnRadius;
 export const SHIP_MAX_VELOCITY = 70;
 export const BULLET_DAMAGE = 100;

--- a/src/examples/spaceshooter/systems/shipSystem.ts
+++ b/src/examples/spaceshooter/systems/shipSystem.ts
@@ -11,7 +11,7 @@ import {
 } from '../../spaceshooter';
 import level from '../levels/level_1';
 
-export const SHIP_THRUST_RATE = 85;
+export const SHIP_THRUST_RATE = 95;
 export const SHIP_ROTATION_RATE = Math.fround(Math.PI / 0.55); //was 0.7
 export const SHIP_RESPAWN_RADIUS = level.spawnRadius;
 export const SHIP_MAX_VELOCITY = 80;

--- a/src/examples/spaceshooter/systems/shipSystem.ts
+++ b/src/examples/spaceshooter/systems/shipSystem.ts
@@ -11,10 +11,10 @@ import {
 } from '../../spaceshooter';
 import level from '../levels/level_1';
 
-export const SHIP_THRUST_RATE = 95;
-export const SHIP_ROTATION_RATE = Math.fround(Math.PI / 0.55); //was 0.7
+export const SHIP_THRUST_RATE = 60;
+export const SHIP_ROTATION_RATE = Math.fround(Math.PI / 0.6); //was 0.7
 export const SHIP_RESPAWN_RADIUS = level.spawnRadius;
-export const SHIP_MAX_VELOCITY = 80;
+export const SHIP_MAX_VELOCITY = 70;
 export const BULLET_DAMAGE = 100;
 export const SHIP_BOUNCINESS = 0.8;
 
@@ -142,7 +142,7 @@ function addShip({
     // stats.canShoot[eid] = 1;
     position.x[eid] = eid / 100;
     collider.type[eid] = ColliderType.Circle;
-    collider.radius[eid] = 2;
+    collider.radius[eid] = 5;
     physics.applyRotation[eid] = 0;
     physics.drag[eid] = 0.01;
     physics.bounciness[eid] = SHIP_BOUNCINESS;

--- a/src/examples/spaceshooter/utils/PhysicsUtils.ts
+++ b/src/examples/spaceshooter/utils/PhysicsUtils.ts
@@ -29,20 +29,19 @@ export function reflectVector(velocity: Vector2, normal: Vector2): Vector2 {
     };
 }
 
+function crossProduct(p1: Vector2, p2: Vector2): number {
+    return Math.fround(p1.x * p2.y - p1.y * p2.x);
+}
+
+function subtractPoints(p1: Vector2, p2: Vector2): Vector2 {
+    return { x: Math.fround(p1.x - p2.x), y: Math.fround(p1.y - p2.y) };
+}
+
 export function pointInRectangle(
     point: Vector2,
     rectangle: Rectangle,
 ): boolean {
     const { a, b, c, d } = rectangle;
-
-    function crossProduct(p1: Vector2, p2: Vector2): number {
-        return Math.fround(p1.x * p2.y - p1.y * p2.x);
-    }
-
-    function subtractPoints(p1: Vector2, p2: Vector2): Vector2 {
-        return { x: Math.fround(p1.x - p2.x), y: Math.fround(p1.y - p2.y) };
-    }
-
     const AB = subtractPoints(b, a);
     const AP = subtractPoints(point, a);
     const BC = subtractPoints(c, b);
@@ -62,6 +61,15 @@ export function pointInRectangle(
         (cross1 >= 0 && cross2 >= 0 && cross3 >= 0 && cross4 >= 0)
     );
 }
+
+function distanceSquared(p1: Vector2, p2: Vector2): number {
+    return Math.fround((p1.x - p2.x) ** 2 + (p1.y - p2.y) ** 2);
+}
+
+function dotProduct(p1: Vector2, p2: Vector2): number {
+    return Math.fround(p1.x * p2.x + p1.y * p2.y);
+}
+
 function intersectCircle(
     circle: Circle,
     segment: [Vector2, Vector2],
@@ -69,20 +77,11 @@ function intersectCircle(
     const { center, radius } = circle;
     const [p1, p2] = segment;
 
-    function distanceSquared(p1: Vector2, p2: Vector2): number {
-        return Math.fround((p1.x - p2.x) ** 2 + (p1.y - p2.y) ** 2);
-    }
-
-    function dotProduct(p1: Vector2, p2: Vector2): number {
-        return Math.fround(p1.x * p2.x + p1.y * p2.y);
-    }
-
-    function closestPointOnSegment(): Vector2 {
-        const segmentLengthSquared = distanceSquared(p1, p2);
-        if (segmentLengthSquared === 0) {
-            return p1;
-        }
-
+    let closestPoint: Vector2;
+    const segmentLengthSquared = distanceSquared(p1, p2);
+    if (segmentLengthSquared === 0) {
+        closestPoint = p1;
+    } else {
         const t = Math.max(
             0,
             Math.min(
@@ -94,13 +93,12 @@ function intersectCircle(
             ),
         );
 
-        return {
+        closestPoint = {
             x: Math.fround(p1.x + t * (p2.x - p1.x)),
             y: Math.fround(p1.y + t * (p2.y - p1.y)),
         };
     }
 
-    const closestPoint = closestPointOnSegment();
     return {
         intersects:
             distanceSquared(center, closestPoint) <= Math.fround(radius ** 2),

--- a/src/examples/spaceshooter/utils/PhysicsUtils.ts
+++ b/src/examples/spaceshooter/utils/PhysicsUtils.ts
@@ -163,7 +163,7 @@ export function intersectCircleRectangle(
         };
     }
     if (pointInRectangle(center, rectangle)) {
-        console.log('too far inside geometry - wind it back');
+        // console.log('too far inside geometry - wind it back');
         const normalizedVelocity = NormalizeVector2(velocity);
         const newPoint = {
             x: Math.fround(center.x - normalizedVelocity.x * radius),

--- a/src/examples/spaceshooter/utils/RenderUtils.ts
+++ b/src/examples/spaceshooter/utils/RenderUtils.ts
@@ -174,7 +174,6 @@ export function useParticleEffect(
     const asset = useRef<ParticleEffectData | null>(null);
     const effect = useRef<ParticleEffect | null>(null);
     useAsyncEffect(async () => {
-        console.log('loading particle effect');
         const data = new ParticleEffectData(config);
         await data.prepare();
         asset.current = data;

--- a/src/examples/spaceshooter/utils/RenderUtils.ts
+++ b/src/examples/spaceshooter/utils/RenderUtils.ts
@@ -23,9 +23,9 @@ export enum InterpolateMethod {
 
 export enum InterpolateSpeed {
     Snap = -1,
-    Fastest = 9,
-    Quick = 5,
-    Smooth = 2.5,
+    Fastest = 10,
+    Quick = 7,
+    Smooth = 4,
     Slow = 0.5,
 }
 

--- a/src/gui/components/ChannelView.tsx
+++ b/src/gui/components/ChannelView.tsx
@@ -23,7 +23,7 @@ import { Operation, TerminalView } from './Terminal';
 import termstyles from './Terminal.module.css';
 
 const MAX_PLAYERS = 4;
-export const FIXED_UPDATE_RATE = 100;
+export const FIXED_UPDATE_RATE = 66;
 export const INTERLACE = 3;
 export const SIM_INPUT_DELAY = 0; // number of ticks to avoid
 export const SIM_END = SESSION_TIME_SECONDS / (FIXED_UPDATE_RATE / 1000);
@@ -137,11 +137,6 @@ export default memo(function ChannelView({
         [],
         [],
     );
-
-    // const largestDiff = peers.reduce(
-    //     (acc, peer) => Math.max(acc, peer.knownHeight - peer.validHeight),
-    //     0,
-    // );
 
     // a peer is "ready" if it can see all other peers
     // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -336,8 +331,14 @@ export default memo(function ChannelView({
                                     )
                                 ) : (
                                     <span>
+                                        <br />
+                                        <br />
+                                        <br />
                                         <Spinner /> Waiting for Playerchain
                                         peers
+                                        <br />
+                                        <br />
+                                        <br />
                                     </span>
                                 ),
                                 promise: () =>
@@ -350,10 +351,23 @@ export default memo(function ChannelView({
                                     <span
                                         className={termstyles.promptTextColor}
                                     >
-                                        Start again:
+                                        Keep waiting for peers to connect or
+                                        abort:
+                                        <br />
+                                        <br />
                                     </span>
                                 ),
-                                choices: [{ text: 'Return to start', next: 1 }],
+                                choices: [
+                                    {
+                                        text: 'Keep waiting',
+                                        noop: true,
+                                        next: 0,
+                                    },
+                                    {
+                                        text: 'Abort session and start again',
+                                        next: 1,
+                                    },
+                                ],
                                 promise: () =>
                                     new Promise((resolve) => {
                                         setTimeout(resolve, TERM_DELAY);
@@ -440,7 +454,7 @@ export default memo(function ChannelView({
                     >
                         {muted ? 'volume_off' : 'volume_up'}
                     </span>
-                    <Connectivity metric={metrics.cps} />
+                    {majorityReady && <Connectivity metric={metrics.cps} />}
                 </div>
             </div>
             {details && (

--- a/src/gui/components/ChannelView.tsx
+++ b/src/gui/components/ChannelView.tsx
@@ -181,10 +181,6 @@ export default memo(function ChannelView({
 
     const majorityReady = readyPeers >= required;
     const selfIsInTheClub = channel.peers.includes(peerId);
-    const channelIsFull = channel.peers.length >= MAX_PLAYERS;
-    const failedToJoinMessage = channelIsFull
-        ? '⛔ This session is currently full.'
-        : '⛔ This session is already in progress.';
 
     const terminalFlow: Operation[] = [
         {
@@ -333,7 +329,11 @@ export default memo(function ChannelView({
                         flow={[
                             {
                                 text: !selfIsInTheClub ? (
-                                    failedToJoinMessage
+                                    channel.peers.length >= MAX_PLAYERS ? (
+                                        '⛔ This session is currently full.'
+                                    ) : (
+                                        '⛔ This session is already in progress.'
+                                    )
                                 ) : (
                                     <span>
                                         <Spinner /> Waiting for Playerchain
@@ -440,10 +440,7 @@ export default memo(function ChannelView({
                     >
                         {muted ? 'volume_off' : 'volume_up'}
                     </span>
-                    <Connectivity
-                        metric={metrics.cps}
-                        peerCount={channel.peers.length}
-                    />
+                    <Connectivity metric={metrics.cps} />
                 </div>
             </div>
             {details && (

--- a/src/gui/components/ChannelView.tsx
+++ b/src/gui/components/ChannelView.tsx
@@ -23,8 +23,8 @@ import { Operation, TerminalView } from './Terminal';
 import termstyles from './Terminal.module.css';
 
 const MAX_PLAYERS = 4;
-export const FIXED_UPDATE_RATE = 66;
-export const INTERLACE = 3;
+export const FIXED_UPDATE_RATE = 100;
+export const INTERLACE = 4;
 export const SIM_INPUT_DELAY = 0; // number of ticks to avoid
 export const SIM_END = SESSION_TIME_SECONDS / (FIXED_UPDATE_RATE / 1000);
 

--- a/src/gui/components/ChannelView.tsx
+++ b/src/gui/components/ChannelView.tsx
@@ -23,8 +23,8 @@ import { Operation, TerminalView } from './Terminal';
 import termstyles from './Terminal.module.css';
 
 const MAX_PLAYERS = 4;
-export const FIXED_UPDATE_RATE = 50;
-export const INTERLACE = 4;
+export const FIXED_UPDATE_RATE = 45;
+export const INTERLACE = 10;
 export const SIM_INPUT_DELAY = 0; // number of ticks to avoid
 export const SIM_END = SESSION_TIME_SECONDS / (FIXED_UPDATE_RATE / 1000);
 

--- a/src/gui/components/ChannelView.tsx
+++ b/src/gui/components/ChannelView.tsx
@@ -23,8 +23,8 @@ import { Operation, TerminalView } from './Terminal';
 import termstyles from './Terminal.module.css';
 
 const MAX_PLAYERS = 4;
-export const FIXED_UPDATE_RATE = 66;
-export const INTERLACE = 5;
+export const FIXED_UPDATE_RATE = 100;
+export const INTERLACE = 3;
 export const SIM_INPUT_DELAY = 0; // number of ticks to avoid
 export const SIM_END = SESSION_TIME_SECONDS / (FIXED_UPDATE_RATE / 1000);
 

--- a/src/gui/components/ChannelView.tsx
+++ b/src/gui/components/ChannelView.tsx
@@ -24,7 +24,7 @@ import termstyles from './Terminal.module.css';
 
 const MAX_PLAYERS = 4;
 export const FIXED_UPDATE_RATE = 100;
-export const INTERLACE = 4;
+export const INTERLACE = 3;
 export const SIM_INPUT_DELAY = 0; // number of ticks to avoid
 export const SIM_END = SESSION_TIME_SECONDS / (FIXED_UPDATE_RATE / 1000);
 

--- a/src/gui/components/ChannelView.tsx
+++ b/src/gui/components/ChannelView.tsx
@@ -23,8 +23,8 @@ import { Operation, TerminalView } from './Terminal';
 import termstyles from './Terminal.module.css';
 
 const MAX_PLAYERS = 4;
-export const FIXED_UPDATE_RATE = 45;
-export const INTERLACE = 10;
+export const FIXED_UPDATE_RATE = 66;
+export const INTERLACE = 5;
 export const SIM_INPUT_DELAY = 0; // number of ticks to avoid
 export const SIM_END = SESSION_TIME_SECONDS / (FIXED_UPDATE_RATE / 1000);
 

--- a/src/gui/components/Connectivity.tsx
+++ b/src/gui/components/Connectivity.tsx
@@ -27,23 +27,24 @@ export default memo(function Connectivity({ metric }: { metric: Metric }) {
 
     useEffect(() => {
         let n = 0;
-        let values = [-1, -1, 1, -1];
-        let hasBeenZeroBefore = false;
+        let values = [-1, -1, -1];
+        let active = false;
         let prevStatus = STATUS_OK;
         return metric.subscribe((value) => {
             values[n % values.length] = value;
             n++;
-            if (!hasBeenZeroBefore && values.every((v) => v > 0)) {
-                hasBeenZeroBefore = true;
+            const probablyActive = values.every((v) => v > -1);
+            if (!active && probablyActive) {
+                active = true;
                 values = values.slice(-2);
                 n = 0;
+            } else if (active && !probablyActive) {
+                active = false;
             }
-            const isBad =
-                hasBeenZeroBefore && values.every((v) => v > -1 && v < 2);
+            const isBad = active && values.every((v) => v > -1 && v < 2);
             const isPoor =
                 isBad ||
-                (hasBeenZeroBefore &&
-                    values.every((v) => v > -1 && v <= POOR_THRESHOLD));
+                (active && values.every((v) => v > -1 && v <= POOR_THRESHOLD));
             const newStatus = isBad
                 ? STATUS_BAD
                 : isPoor

--- a/src/gui/components/Renderer.tsx
+++ b/src/gui/components/Renderer.tsx
@@ -108,14 +108,11 @@ export default memo(function Renderer({
                 interlace,
                 channelPeerIds,
                 peerId,
-                // metrics,
                 dbname,
             };
-            console.log('starting sequencer----------1', cfg);
             const seq = await new SequencerProxy(
                 Comlink.transfer(cfg, [cfg.clientPort]),
             );
-            console.log('starting sequencer----------2');
             seq.start().catch((err) => {
                 console.error('seq.start err:', err);
             });
@@ -125,17 +122,7 @@ export default memo(function Renderer({
             console.log('started sequencer');
             return seq;
         },
-        [
-            client,
-            channelId,
-            rate,
-            src,
-            peerId,
-            db,
-            channelPeerIds,
-            interlace,
-            metrics,
-        ],
+        [client, channelId, rate, src, peerId, db, channelPeerIds, interlace],
     );
 
     // configure event handlers

--- a/src/gui/components/Stat.tsx
+++ b/src/gui/components/Stat.tsx
@@ -1,6 +1,6 @@
 // const Stats = function () {
 //     let mode = 0;
-import { useEffect, useRef, useState } from 'react';
+import { memo, useEffect, useRef, useState } from 'react';
 import { Metric } from '../../runtime/metrics';
 
 // port of MrDoob's stats.js
@@ -121,7 +121,7 @@ class Panel {
     }
 }
 
-export default function Stat({ metric }: { metric: Metric }) {
+export default memo(function Stat({ metric }: { metric: Metric }) {
     const [panel, setPanel] = useState<Panel | null>(null);
     const canvasRef = useRef<HTMLCanvasElement>(null);
     useEffect(() => {
@@ -139,7 +139,7 @@ export default function Stat({ metric }: { metric: Metric }) {
         if (!panel) {
             return;
         }
-        metric.subscribe((value) => {
+        return metric.subscribe((value) => {
             panel.update(value, metric.max);
         });
     }, [metric, panel]);
@@ -150,4 +150,4 @@ export default function Stat({ metric }: { metric: Metric }) {
             style={{ height: '4rem', marginTop: '1rem', marginLeft: '5px' }}
         />
     );
-}
+});

--- a/src/gui/components/Stat.tsx
+++ b/src/gui/components/Stat.tsx
@@ -140,7 +140,7 @@ export default memo(function Stat({ metric }: { metric: Metric }) {
             return;
         }
         return metric.subscribe((value) => {
-            panel.update(value, metric.max);
+            panel.update(Math.max(0, value), metric.max);
         });
     }, [metric, panel]);
     return (

--- a/src/gui/components/StatusBar.tsx
+++ b/src/gui/components/StatusBar.tsx
@@ -56,7 +56,9 @@ export default memo(function StatusBar({
                 .then((tx) => {
                     const newHeight = tx?.height ?? 0;
                     const diff = newHeight - prevHeight;
-                    metrics.cps.add(diff);
+                    if (newHeight > 1) {
+                        metrics.cps.add(diff);
+                    }
                     setInfo((prev) => ({ ...prev, tx: newHeight }));
                     prevHeight = newHeight;
                 })

--- a/src/gui/components/Terminal.tsx
+++ b/src/gui/components/Terminal.tsx
@@ -33,6 +33,7 @@ export interface Operation {
 export interface Choice {
     text: string;
     next: number;
+    noop?: boolean;
 }
 
 interface OperationText {
@@ -236,6 +237,9 @@ export const TerminalView: FunctionComponent<TerminalViewProps> = ({
                     e.preventDefault();
                     const choice = flow[opIndex].choices![currentChoice];
                     if (choice) {
+                        if (choice.noop) {
+                            return;
+                        }
                         setOpIndex(opIndex + choice.next);
                         setIsOperationInProgress(false);
                     }

--- a/src/gui/hooks/use-client.tsx
+++ b/src/gui/hooks/use-client.tsx
@@ -8,6 +8,7 @@ export type ClientUserConfig = Omit<
 
 export interface ClientContextType {
     commit: Client['commit'];
+    enqueue: Client['enqueue'];
     send: Client['send'];
     createChannel: Client['createChannel'];
     joinChannel: Client['joinChannel'];

--- a/src/gui/workers/client.worker.ts
+++ b/src/gui/workers/client.worker.ts
@@ -43,6 +43,10 @@ export async function commit(
     return client!.commit(msg, channelId);
 }
 
+export async function enqueue(msg: ChainMessage, channelId: string | null) {
+    return client!.enqueue(msg, channelId);
+}
+
 export async function send(msg: Message, opts?: EmitOpts) {
     return client!.send(msg, opts);
 }
@@ -70,5 +74,6 @@ const exports = {
     joinChannel,
     setPeers,
     shutdown,
+    enqueue,
 };
 Comlink.expose(exports);

--- a/src/runtime/client.ts
+++ b/src/runtime/client.ts
@@ -687,57 +687,6 @@ export class Client {
                 console.warn('ignoring invalid channel id', ch);
                 continue;
             }
-            // send channel keep alive
-            // see channel.ts ... this is a workaround for a bug
-            // and also how player names get broadcasted... (lol)
-
-            const subclusterPeers = ch.subcluster.peers();
-            const peerName = await this.db.peerNames.get(this.peerId);
-            await ch.send(
-                {
-                    type: MessageType.KEEP_ALIVE,
-                    peer: this.id,
-                    timestamp: Date.now(),
-                    sees: subclusterPeers.map(
-                        (p) =>
-                            Buffer.from(
-                                p.peerId.slice(0, 8),
-                                'hex',
-                            ) as unknown as Uint8Array,
-                    ),
-                    name: peerName?.name || '',
-                },
-                {
-                    ttl: DEFAULT_TTL,
-                },
-            );
-            // sync channel name with genesis and rebroadcast it
-            // const subclusterPeerIds = subclusterPeers
-            //     .map((p) => p.peerId.slice(0, 8))
-            //     .sort()
-            //     .join(',');
-            // const dbPeers = (await this.db.peers.toArray())
-            //     .map((p) => p.peerId.slice(0, 8))
-            //     .sort()
-            //     .join(',');
-            // const alivePeers = Array.from(ch.alivePeerIds.keys())
-            //     .map((peerId) => peerId.slice(0, 8))
-            //     .sort()
-            //     .join(',');
-            // const lastKnowPeers = Array.from(ch.lastKnowPeers.keys())
-            //     .map((peerId) => peerId.slice(0, 8))
-            //     .sort()
-            //     .join(',');
-            // const netPeers = Array.from(this.net.socket.peers.keys())
-            //     .map((peerId) => peerId.slice(0, 8))
-            //     .sort()
-            //     .join(',');
-            // this.debug(`
-            //     peer-info
-            //     subclusterPeers=${subclusterPeerIds}
-            //     lastKnowPeers=${lastKnowPeers}
-            //     alivePeers=${alivePeers}
-            // `);
             const info = await this.db.channels.get(ch.id);
             if (info) {
                 if (info.peers.length === 0) {

--- a/src/runtime/metrics.ts
+++ b/src/runtime/metrics.ts
@@ -1,10 +1,11 @@
+export type CancelSubscription = () => void;
 export type Metric = {
     name: string;
     description: string;
     max: number;
     add: (n: number) => void;
     set: (value: number) => void;
-    subscribe: (callback: (value: number) => void) => void;
+    subscribe: (callback: (value: number) => void) => CancelSubscription;
 };
 
 export type MetricConfig = {
@@ -42,7 +43,7 @@ export function createMetric({
             }
         },
         set,
-        subscribe(callback: (value: number) => void) {
+        subscribe(callback: (value: number) => void): CancelSubscription {
             callbacks.push(callback);
             return () => {
                 const index = callbacks.indexOf(callback);

--- a/src/runtime/network/Peer.ts
+++ b/src/runtime/network/Peer.ts
@@ -979,7 +979,6 @@ export class Peer {
         await this.mcast(packet);
         this.gate.set(packet.packetId.toString('hex'), 1);
 
-        console.log('-------------------JOINED');
         return Comlink.proxy(subcluster);
     }
 
@@ -1265,9 +1264,9 @@ export class Peer {
             if (peer.proxies.size > 0) {
                 // remove any proxies that were previously assigned
                 // because we are now directly connected
-                console.log(
-                    `SHOULD REMOVE PROXIES, DIRECT CONNECTION ESTABLISHED`,
-                );
+                // console.log(
+                //     `SHOULD REMOVE PROXIES, DIRECT CONNECTION ESTABLISHED`,
+                // );
                 // this._onDebug(
                 //     `<- CONNECTION REMOVING PROXY PEER (id=${peer.peerId}, address=${address}:${port} count=${peer.proxies.size - 1})`,
                 // );

--- a/src/runtime/network/Subcluster.ts
+++ b/src/runtime/network/Subcluster.ts
@@ -1,5 +1,7 @@
+import _sodium from 'libsodium-wrappers';
 import { Buffer } from 'socket:buffer';
 import { isBufferLike } from 'socket:util';
+import { ChainMessage, Message, MessageType, decodeMessage } from '../messages';
 import type Peer from './Peer';
 import type { Keys } from './Peer';
 import { Encryption } from './encryption';
@@ -23,8 +25,9 @@ export class Subcluster {
     sharedKey: Uint8Array;
     signingKeys: Keys;
     localPeer: Peer;
-    onMsg?: (msg: Buffer) => void;
+    onMsg?: (msg: Message, id: string) => void;
     onRPC?: (msg: Buffer) => void;
+    seen: Set<string> = new Set();
 
     constructor(config: SubclusterConfig) {
         this.signingKeys = config.signingKeys;
@@ -36,12 +39,24 @@ export class Subcluster {
         this.localPeer = config.localPeer;
     }
 
+    async set(key: string, value: any) {
+        this[key] = value;
+    }
+
     // find all peers connecetd to the localPeer that we know have
     // registreed an interest in this subcluster
-    peers() {
+    private peers() {
         return Array.from(this.localPeer.peers.values()).filter((p) =>
             this.localPeer.peerMapping.get(p.peerId)?.has(this.scid),
         );
+    }
+
+    async getPeerInfo() {
+        return this.peers().map((p) => ({
+            peerId: p.peerId,
+            connected: !!p.connected,
+            proxy: !!p.proxies.size,
+        }));
     }
 
     async stream(eventName, value, opts: any = {}) {
@@ -161,7 +176,31 @@ export class Subcluster {
         switch (eventName) {
             case 'msg':
                 if (this.onMsg) {
-                    this.onMsg(opened);
+                    const m = decodeMessage(opened);
+                    if (m.type !== MessageType.KEEP_ALIVE) {
+                        // verify it
+                        const [verified, id] = await this.verify(m);
+                        if (!verified) {
+                            return;
+                        }
+                        if (!id) {
+                            return;
+                        }
+                        if (!m.sig) {
+                            return;
+                        }
+                        // if (m.type === MessageType.INPUT) {
+                        //     const sig = Buffer.from(m.sig).toString('hex');
+                        //     if (this.seen.has(sig)) {
+                        //         console.log('seen that one');
+                        //         return;
+                        //     }
+                        //     this.seen.add(sig);
+                        // }
+                        this.onMsg(m, id);
+                    } else {
+                        this.onMsg(m, '');
+                    }
                 }
                 return;
             case 'rpc':
@@ -173,5 +212,64 @@ export class Subcluster {
                 console.warn('unknown event', eventName);
                 return;
         }
+    }
+
+    async verify(msg: ChainMessage): Promise<[true, string] | [false, null]> {
+        await _sodium.ready;
+        const sodium = _sodium;
+        // return true;
+        try {
+            const { sig, ...unsigned } = msg;
+            if (!sig) {
+                throw new Error('no-sig');
+            }
+            const hash = await this.hash(unsigned);
+            const pk = msg.peer;
+            if (!pk) {
+                throw new Error('no-pk');
+            }
+            const ok = sodium.crypto_sign_verify_detached(sig, hash, pk);
+            if (!ok) {
+                return [false, null];
+            }
+            // 64bits of the hash is the id
+            // FIXME: we should think about this carefully!
+            // this truncation does not affect the signature, but it does affect
+            // the acks which are based on the id ... the pool of ids is not global
+            // as it is per peer set, so _some_ truncation here can be tollerated
+            // but it is possible for collisions in the db, so we may need to
+            // store the with a composite key of peer and id
+            const id = Buffer.from(hash.slice(0, 8)).toString('base64');
+            return [true, id];
+        } catch (err) {
+            console.error(`
+                verify-error
+                msg=${msg}
+                err=${err}
+            `);
+            return [false, null];
+        }
+    }
+
+    async hash(msg: ChainMessage): Promise<Uint8Array> {
+        await _sodium.ready;
+        const sodium = _sodium;
+        const values = [
+            Buffer.from(msg.peer).toString('hex'),
+            msg.parent ? Buffer.from(msg.parent).toString('base64') : null,
+            msg.height,
+            msg.type,
+            msg.acks
+                ? msg.acks.map((a) => Buffer.from(a).toString('base64'))
+                : [],
+            (msg as any).data || 0,
+            (msg as any).round || 0,
+        ];
+        const data = JSON.stringify(values);
+        // FIXME: is "BYTES_MIN" enough?
+        return sodium.crypto_generichash(
+            sodium.crypto_generichash_BYTES_MIN,
+            data,
+        );
     }
 }

--- a/src/runtime/network/worker.ts
+++ b/src/runtime/network/worker.ts
@@ -1,0 +1,4 @@
+import * as Comlink from 'comlink';
+import { Peer } from './Peer';
+
+Comlink.expose(Peer);

--- a/src/runtime/sequencer.ts
+++ b/src/runtime/sequencer.ts
@@ -43,7 +43,7 @@ export const requiredConfirmationsFor = (size: number): number => {
         case 2:
             return 2;
         case 3:
-            return 3;
+            return 2;
         case 4:
             return 3;
         case 5:
@@ -147,7 +147,7 @@ export class Sequencer {
 
         // skip if we just did that round
         if (this.prevRound !== null && round <= this.prevRound) {
-            // console.log('seq-no-new-round', round);
+            console.log('seq-no-new-round', round);
             return 0;
         }
         // get the current input state
@@ -161,7 +161,7 @@ export class Sequencer {
             const [numCommits, ackIds, jumpRound] =
                 await this.canWriteInputBlock(input, round);
             if (!numCommits) {
-                // console.log('seq-cannot-write-block', round);
+                console.log('seq-cannot-write-block', round);
                 await new Promise((resolve) => setTimeout(resolve, 1));
                 continue;
             }
@@ -298,9 +298,9 @@ export class Sequencer {
                 ? this.channelPeerIds.length - 1
                 : requiredConfirmationsFor(this.channelPeerIds.length) - 1;
         if (ackIds.length < requiredBlocks) {
-            // console.log(
-            //     `[seq/${this.peerId.slice(0, 8)}] BLOCKED NOTENOUGPREV round=${round} got=${ackIds.length} need=${requiredBlocks}`,
-            // );
+            console.log(
+                `[seq/${this.peerId.slice(0, 8)}] BLOCKED NOTENOUGPREV round=${round} got=${ackIds.length} need=${requiredBlocks}`,
+            );
             return [0, null, round];
         }
 

--- a/src/runtime/sequencer.ts
+++ b/src/runtime/sequencer.ts
@@ -10,6 +10,7 @@ import database, { DB } from './db';
 import { GameModule, load } from './game';
 import { InputMessage, MessageType } from './messages';
 import { DefaultMetrics } from './metrics';
+import { sleep } from './timers';
 import { CancelFunction } from './utils';
 
 export interface Committer {
@@ -162,7 +163,7 @@ export class Sequencer {
                 await this.canWriteInputBlock(input, round);
             if (!numCommits) {
                 console.log('seq-cannot-write-block', round);
-                await new Promise((resolve) => setTimeout(resolve, 1));
+                await sleep(2);
                 continue;
             }
             if (jumpRound !== round) {

--- a/src/runtime/sequencer.ts
+++ b/src/runtime/sequencer.ts
@@ -162,7 +162,7 @@ export class Sequencer {
             const [numCommits, ackIds, jumpRound] =
                 await this.canWriteInputBlock(input, round);
             if (!numCommits) {
-                console.log('seq-cannot-write-block', round);
+                // console.log('seq-cannot-write-block', round);
                 await sleep(2);
                 continue;
             }
@@ -299,9 +299,9 @@ export class Sequencer {
                 ? this.channelPeerIds.length - 1
                 : requiredConfirmationsFor(this.channelPeerIds.length) - 1;
         if (ackIds.length < requiredBlocks) {
-            console.log(
-                `[seq/${this.peerId.slice(0, 8)}] BLOCKED NOTENOUGPREV round=${round} got=${ackIds.length} need=${requiredBlocks}`,
-            );
+            // console.log(
+            //     `[seq/${this.peerId.slice(0, 8)}] BLOCKED NOTENOUGPREV round=${round} got=${ackIds.length} need=${requiredBlocks}`,
+            // );
             return [0, null, round];
         }
 

--- a/src/runtime/sequencer.ts
+++ b/src/runtime/sequencer.ts
@@ -76,7 +76,6 @@ export class Sequencer {
     private inputDelay = 100;
     private mode: SequencerMode;
     private interlace: number;
-    private metrics?: DefaultMetrics;
     private end: number;
     private skew = 0;
     peerId: string;
@@ -94,7 +93,6 @@ export class Sequencer {
         channelPeerIds,
         interlace,
         rate,
-        metrics,
     }: SequencerConfig) {
         this.db = database.open(dbname);
         this.mode = mode;
@@ -106,7 +104,6 @@ export class Sequencer {
         this.channelPeerIds = channelPeerIds;
         this.fixedUpdateRate = rate;
         this.warmingUp = (1000 / this.fixedUpdateRate) * 1; // 1s warmup
-        this.metrics = metrics;
         this.end =
             SESSION_TIME_SECONDS / (this.fixedUpdateRate / 1000) +
             this.interlace;
@@ -117,10 +114,7 @@ export class Sequencer {
             return;
         }
         try {
-            const commits = await this._loop();
-            if (this.metrics) {
-                this.metrics.cps.add(commits);
-            }
+            await this._loop();
         } catch (err) {
             console.error(`seq-loop-err`, err);
         } finally {

--- a/src/runtime/simulation.ts
+++ b/src/runtime/simulation.ts
@@ -103,10 +103,10 @@ export class Simulation {
 
     private async getCurrentRoundLimitFromMessages(): Promise<number> {
         const latest = (await this.db.messages
-            .where(['channel', 'round', 'peer'])
+            .where(['channel', 'peer', 'round'])
             .between(
-                [this.channelId, Dexie.minKey, Dexie.minKey],
-                [this.channelId, Dexie.maxKey, Dexie.maxKey],
+                [this.channelId, this.peerId, Dexie.minKey],
+                [this.channelId, this.peerId, Dexie.maxKey],
             )
             .last()) as InputMessage | undefined;
         if (!latest) {

--- a/src/runtime/simulation.ts
+++ b/src/runtime/simulation.ts
@@ -1,5 +1,5 @@
 import Dexie from 'dexie';
-import database, { DB, SerializedState, StateTag, StoredMessage } from './db';
+import database, { DB, SerializedState, StateTag } from './db';
 import { GameModule, PlayerData, load } from './game';
 import { IncrementalCache } from './lru';
 import { InputMessage, MessageType } from './messages';
@@ -14,7 +14,6 @@ export type State = {
 export type RoundInput = {
     round: number;
     updated: number;
-    delta: number;
     unconfirmed?: boolean;
     inputs: PlayerData[];
 };
@@ -66,7 +65,7 @@ export class Simulation {
         interlace,
     }: SimulationConfig) {
         this.peerId = peerId;
-        this.channelPeerIds = channelPeerIds;
+        this.channelPeerIds = channelPeerIds.sort((a, b) => (a < b ? -1 : 1));
         this.mode = mode;
         this.inputDelay = inputDelay;
         this.interlace = interlace;
@@ -164,28 +163,21 @@ export class Simulation {
             await this.db.state.put(serialized);
             latestState = serialized;
         }
-        // have we seen any new messages since then that invalidate it?
+        // have any of the tapes changed since then?
         let startFromRound = latestState.round;
-        await this.db.messages
+        await this.db.tapes
             .where(['channel', 'updated'])
             .between(
                 [this.channelId, latestState.updated + 1],
                 [this.channelId, Dexie.maxKey],
             )
-            .each((m) => {
-                if (m.type !== MessageType.INPUT) {
-                    return;
-                }
-                if (m.peer && !this.channelPeerIds.includes(m.peer)) {
-                    // ignore messages from peers not accepted in the set
-                    return;
-                }
-                if (m.round <= startFromRound) {
-                    startFromRound = m.round - 1;
+            .each((tape) => {
+                if (tape.round <= startFromRound) {
+                    startFromRound = tape.round - 1;
                 }
             });
         // always fetch enough to recalculate the wave
-        startFromRound = Math.max(startFromRound - this.interlace * 2, 1); // THINK: can we reduce num of fetched wave msgs
+        startFromRound = Math.max(startFromRound - 1, 1); // FIXME: this need to fetch interlace*2 rounds, removed while working on 4xplayer
         // find the closest state to satisfy startFromRound
         // if we're already at the round we need, return it
         if (latestState.round === startFromRound) {
@@ -239,170 +231,128 @@ export class Simulation {
             targetRound,
         );
 
-        const { messages, rollbackState, fromRound } =
-            await this.db.transaction(
-                'rw',
-                [this.db.state, this.db.messages] as any,
-                async () => {
-                    // find the round we need to process from
-                    const rollbackState = await this.getRollbackState(toRound);
-                    const fromRound = rollbackState.round;
+        // find the round we need to process from
+        const rollbackState = await this.getRollbackState(toRound);
+        const fromRound = rollbackState.round;
 
-                    // santize the range
-                    if (toRound <= fromRound) {
-                        throw new Error(
-                            'invalid-round-range: toRound cannot be before fromRound',
-                        );
-                    }
-
-                    // get all the messages that occured in the range
-                    const messages = (
-                        await this.db.messages
-                            .where(['channel', 'round', 'peer'])
-                            .between(
-                                [this.channelId, fromRound + 1, Dexie.minKey],
-                                [this.channelId, toRound, Dexie.maxKey],
-                            )
-                            .toArray()
-                    )
-                        .filter((m) => m.type === MessageType.INPUT)
-                        .filter(
-                            (m) =>
-                                m.peer && this.channelPeerIds.includes(m.peer),
-                        )
-                        .sort((a, b) => {
-                            return a.round - b.round;
-                        });
-                    return { messages, rollbackState, fromRound };
-                },
+        // santize the range
+        if (toRound <= fromRound) {
+            throw new Error(
+                'invalid-round-range: toRound cannot be before fromRound',
             );
+        }
+
+        // get all the tapes in the range
+        const tapes = await this.db.tapes
+            .where(['channel', 'round'])
+            .between([this.channelId, fromRound + 1], [this.channelId, toRound])
+            .toArray();
         // group the messages by round
-        let latestRound: number | null = null;
         let prevUpdated = rollbackState.updated;
-        let prevRound = fromRound;
+        let prevRound: number = rollbackState.round;
         const roundData: RoundInput[] = [];
-        const validMessages = messages.reduce((acc, m) => {
-            if (m.type !== MessageType.INPUT) {
-                return acc;
+        for (const tape of tapes) {
+            if (tape.updated > prevUpdated) {
+                prevUpdated = tape.updated;
             }
-            if (latestRound === null || m.round > latestRound) {
-                latestRound = m.round;
+            let round = roundData.find((r) => r.round === tape.round);
+            if (round) {
+                throw new Error('assert-failed: round already exists');
             }
-            acc.push(m);
-            return acc;
-        }, [] as StoredMessage[]);
-        for (const m of validMessages) {
-            if (latestRound === null) {
-                throw new Error(
-                    'assert-failed: latestRound must not be null here',
-                );
+            // push fake tapes for any delta
+            const delta = tape.round - prevRound - 1;
+            for (let i = 0; i < delta; i++) {
+                prevRound++;
+                roundData.push({
+                    round: prevRound,
+                    updated: prevUpdated,
+                    inputs: this.channelPeerIds.map((id) => ({ id, input: 0 })),
+                });
+                console.log('FAKE TAPE', prevRound);
             }
-            if (m.type !== MessageType.INPUT) {
-                continue;
+            // assert we have not missed any rounds
+            if (tape.round !== prevRound + 1) {
+                throw new Error('assert-failed: missed round');
             }
-            if (m.updated > prevUpdated) {
-                prevUpdated = m.updated;
-            }
-            let round = roundData.find((r) => r.round === m.round);
-            if (!round) {
-                round = {
-                    round: m.round,
-                    updated: m.updated,
-                    delta: m.round - prevRound - 1,
-                    inputs: this.channelPeerIds.map((id) => ({
-                        id,
-                        input: 0,
-                    })),
-                };
-                prevRound = m.round;
-                roundData.push(round);
-                // handle idle
-                if (round.delta > this.idleTimeoutRounds) {
-                    round.delta = this.idleTimeoutRounds;
-                }
-            }
-            if (m.updated > round.updated) {
-                round.updated = m.updated;
-            }
-            if (!m.peer) {
-                throw new Error('input-message-missing-peer');
-            }
-            const inp = round.inputs.find((inp) => inp.id === m.peer);
-            if (!inp) {
-                throw new Error('input-message-peer-not-in-channel');
+            // insert the real tape
+            round = {
+                round: tape.round,
+                updated: tape.updated,
+                inputs: tape.inputs.map((input, i) => ({
+                    id: this.channelPeerIds[i],
+                    input: input > 0 ? input : 0,
+                })),
+            };
+            prevRound = tape.round;
+            roundData.push(round);
+            if (tape.updated > round.updated) {
+                round.updated = tape.updated;
             }
             // if round is at or after the finalization point, then
             // we need to check if the message is accepted or rejected
-            const offsetFromFinalization = latestRound - m.round;
-            const needsFinalization =
-                offsetFromFinalization > this.interlace * 2;
-            let accepted = true;
-            // is well acked?
-            // TODO: reduce this number to supermajority
-            const requiredConfirmations = 0;
-            if (
-                needsFinalization &&
-                m.confirmations[requiredConfirmations] < requiredConfirmations
-            ) {
-                console.log(
-                    `DROP INPUT needed=${requiredConfirmations} got=${m.confirmations[requiredConfirmations]} all=${m.confirmations}`,
-                );
-                accepted = false;
-            }
-            inp.input = accepted && m.type == MessageType.INPUT ? m.data : 0;
+            // const offsetFromFinalization = latestRound - m.round;
+            // const needsFinalization =
+            //     offsetFromFinalization > this.interlace * 2;
+            // let accepted = true;
+            // // is well acked?
+            // // TODO: reduce this number to supermajority
+            // const requiredConfirmations = 0;
+            // if (
+            //     needsFinalization &&
+            //     m.confirmations[requiredConfirmations] < requiredConfirmations
+            // ) {
+            //     console.log(
+            //         `DROP INPUT needed=${requiredConfirmations} got=${m.confirmations[requiredConfirmations]} all=${m.confirmations}`,
+            //     );
+            //     accepted = false;
+            // }
+            // inp.input = accepted && m.type == MessageType.INPUT ? m.data : 0;
 
-            round.unconfirmed = !needsFinalization;
+            // round.unconfirmed = !needsFinalization;
         }
         // apply the messages on top of the state
         let runs = 0;
-        let state = rollbackState.state;
         const checkpoints: SerializedState[] = [];
-        for (const round of roundData) {
-            // if there's a gap in rounds, then delta will be > 0
-            // we should not attempt to fill the gap and should abort
-            if (round.round > 1 && round.delta > 0) {
-                console.log(
-                    `[sim/${this.peerId.slice(0, 8)}] ARGG GAP! THIS IS UNEXPECTED AND LIKELY A BUG!
-                        delta=${round.delta}
-                        round=${round.round}
-                    `,
-                );
-                break;
-            }
-            // ensure inputs are in deterministic order
-            const inputs = round.inputs.sort((a, b) => {
-                return a.id < b.id ? -1 : 1;
-            });
+
+        // load the state into the game
+        const deltaTime = this.fixedUpdateRate / 1000;
+        const initialState = rollbackState.state;
+        const mod = await this.mod;
+        mod.load(initialState.data);
+
+        // the state to render
+        let state = initialState;
+
+        for (let i = 0; i < roundData.length; i++) {
+            const round = roundData[i];
             // check if we already have a state processed for these inputs
             const cachedCheckpoint = this.stateCache.get(round.round);
             if (cachedCheckpoint) {
                 // check the inputs are the same
                 const sameInputs =
-                    cachedCheckpoint.state.inputs.length === inputs.length &&
+                    cachedCheckpoint.state.inputs.length ===
+                        round.inputs.length &&
                     cachedCheckpoint.state.inputs.every((input, i) => {
-                        return input.input === inputs[i].input;
+                        return input.input === round.inputs[i].input;
                     });
                 if (sameInputs) {
+                    cachedCheckpoint.updated = round.updated;
                     state = cachedCheckpoint.state;
+                    mod.load(state.data);
                     continue;
-                    // } else {
-                    //     console.log(
-                    //         'CACHE MISS',
-                    //         JSON.stringify(
-                    //             {
-                    //                 cache: cachedCheckpoint.state.inputs,
-                    //                 inputs,
-                    //             },
-                    //             null,
-                    //             2,
-                    //         ),
-                    //     );
                 }
             }
-            const res = await this.apply(state, round.round, inputs);
-            state = res.state;
-            runs += res.runs;
+            mod.run(round.inputs, deltaTime, round.round);
+            runs++;
+
+            // update first, last and every 200th checkpoints
+            // if (i === 0 || round.round % 200 === 0 || i === roundData.length - 1) {
             // maybe write it if it's a checkpoint round
+            state = {
+                t: round.round,
+                inputs: round.inputs,
+                data: mod.dump(),
+            };
             const checkpoint: SerializedState = {
                 tag: StateTag.ACCEPTED,
                 channel: this.channelId,
@@ -411,18 +361,19 @@ export class Simulation {
                 state,
             };
             // invalidate all states from this point forward
-            await this.db.state
-                .where(['channel', 'tag', 'round'])
-                .between(
-                    [this.channelId, StateTag.ACCEPTED, checkpoint.round],
-                    [this.channelId, StateTag.ACCEPTED, Dexie.maxKey],
-                )
-                .delete();
+            // await this.db.state
+            //     .where(['channel', 'tag', 'round'])
+            //     .between(
+            //         [this.channelId, StateTag.ACCEPTED, checkpoint.round],
+            //         [this.channelId, StateTag.ACCEPTED, Dexie.maxKey],
+            //     )
+            //     .delete();
             if (checkpoint.round % 200 === 0) {
                 // write the checkpoint
                 checkpoints.push(checkpoint);
             }
             this.stateCache.set(checkpoint.round, checkpoint);
+            // }
         }
         // write any state checkpoints to the db
         if (checkpoints.length > 0) {
@@ -434,13 +385,13 @@ export class Simulation {
                     states=${checkpoints.length}
                     applies=${roundData.length}
                     emutick=${Math.min(toRound - prevRound, this.idleTimeoutRounds)}
-                    messages=${messages.length}
+                    tapes=${tapes.length}
                     inputs=${roundData.length}
                     prevUpdated=${prevUpdated}
                 `,
             );
             // write the state to the store
-            await this.db.state.bulkPut(checkpoints);
+            // await this.db.state.bulkPut(checkpoints);
         }
         // console.log(
         //     `simulated
@@ -450,30 +401,6 @@ export class Simulation {
         //         fakes=${fakes}
         //     `,
         // );
-        return { state, runs };
-    }
-
-    private async apply(
-        inState: State,
-        round: number,
-        inputs: PlayerData[],
-    ): Promise<SimResult> {
-        let runs = 0;
-        const deltaTime = this.fixedUpdateRate / 1000;
-        const mod = await this.mod;
-        // clone the world
-        const state = structuredClone(inState);
-        // update player input data
-        state.inputs = inputs.map((input) => ({
-            ...input,
-        }));
-        // tick the game logic forward
-        state.t = round;
-        mod.load(state.data);
-        mod.run(state.inputs, deltaTime, state.t);
-        runs++;
-        state.data = mod.dump();
-        // return the copy of the state
         return { state, runs };
     }
 


### PR DESCRIPTION
attempts to iron out some of the things causing stuttery play

* reduce mesasge/database contention by pre-processing inputs into a "tape" table (rather than processing on demand)
* move network into own thread to avoid blocking packet processing
* change logic for packet commiting to be more agressive about pushing message when ready
* process messages in batches every Nms (rather than as they arrive)
* reduce simulation rate
* reduce physics ticks (this breaks collision checks often, task to repair it: #157 )
* number noodling to make it feel ok at the new update rate (probably not the final numbers but playable)
* reduce re-render of HUD to only once per second rather than whenever the player data changes
* fixes for the connectivity widget to avoid showing at start/end, avoid re-subscribing on each render, and reduce renders
* some minor tweaks to reduce unnecasary physics checks

fixes 

* fixes: #151 
* fixes: #155 