### PR TITLE
genconfig added to `pnpm start`

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "ios:sim": "run-s clean genconfig start:vite && ssc build --platform=ios-simulator --run",
         "start:vite": "vite build --mode=dev",
         "start:ssc": "ssc build --run",
-        "start": "run-s clean start:*",
+        "start": "run-s clean genconfig start:*",
         "build:cli": "vite build --mode=production -c cli.vite.ts",
         "build:vite": "vite build",
         "build": "run-s clean build:*",


### PR DESCRIPTION
## What
Added genconfig to pnpm start

## Why
`pnpm start` had stopped working because it was no longer generating the socket.ini file, and `pnpm dev` currently doesn't work on Windows.