### PR TITLE
Physics optimisation

### DIFF
--- a/src/examples/spaceshooter/systems/physicsSystem.ts
+++ b/src/examples/spaceshooter/systems/physicsSystem.ts
@@ -18,7 +18,6 @@ import {
 } from './shipSystem';
 
 let collisionChecks = 0;
-let bodiesOfConcern = 0;
 
 export default system<ShooterSchema>(
     ({
@@ -33,15 +32,16 @@ export default system<ShooterSchema>(
     }) => {
         const bodies = query(Tags.IsSolidBody);
         const otherBodies = bodies.filter(
-            (eid) => !hasTag(eid, Tags.IsBullet) && entity.active[eid],
+            (eid) =>
+                !hasTag(eid, Tags.IsBullet) &&
+                !hasTag(eid, Tags.IsWall) &&
+                entity.active[eid],
         );
-        console.log('otherBodies', otherBodies.length);
-        const steps = 4; // number of times we check physics between updates
+        const steps = 2; // number of times we check physics between updates
 
         collisionChecks = 0;
-        bodiesOfConcern = 0;
 
-        console.time('physics');
+        // console.time('physics');
         // apply physics
         for (let i = 0; i < steps; i++) {
             for (const eid of bodies) {
@@ -64,8 +64,7 @@ export default system<ShooterSchema>(
                     position.x[eid],
                     position.y[eid],
                 );
-
-                bodiesOfConcern++;
+                const smallSet = [...nearbyEntities.values(), ...otherBodies];
 
                 // set position based on velocity
                 const velocityMagnitude = Math.sqrt(
@@ -103,8 +102,8 @@ export default system<ShooterSchema>(
                     collider.type[eid] === ColliderType.Circle &&
                     entity.active[eid]
                 ) {
-                    // FIXME: was changed from otherBodies to nearbyEntities
-                    for (const otherBody of nearbyEntities) {
+                    // NOTE: was changed from otherBodies to smallSet
+                    for (const otherBody of smallSet) {
                         if (eid === otherBody) {
                             // ignore self
                             continue;
@@ -147,9 +146,8 @@ export default system<ShooterSchema>(
             }
         }
 
-        console.timeEnd('physics');
-        console.log('collisionChecks', collisionChecks);
-        console.log('bodiesOfConcern', bodiesOfConcern);
+        // console.timeEnd('physics');
+        // console.log('collisionChecks', collisionChecks);
     },
 );
 


### PR DESCRIPTION
# What

Instead of bullets and ships checking collisions against all possible map parts (250 odd parts) they only check against parts that are in the same grid cell as them therefore cutting down the number of collision checks dramatically (250ish checks for each ship and bullet to around 8 checks per entity).

# How
Very crudely I've divided up the level into a grid that has cells that are the size of `BULLET_SPEED` which is roughly the size of the area you can see on screen. All the level parts are associated with 1 or more cells and when we do the collision check we get the map parts that are in the same cell as the bullet / ship and only check against those parts.

# Notes

For a 4 player game we have gone from 10ms for 1 step of physics to 0.5ms. As we now have headroom we are now running 2 physics steps per round and from what I've seen, ships are not flying through walls however bullets still can on occasion.