### PR TITLE
Respawn VFX infront of ship

### DIFF
--- a/src/examples/spaceshooter/renderer/ShipEntity.tsx
+++ b/src/examples/spaceshooter/renderer/ShipEntity.tsx
@@ -297,7 +297,7 @@ export default memo(function ShipEntity({
                 world.components.entity.data.generation[eid] !==
                 ship.__generation;
             if (respawned && world.components.entity.data.active[eid]) {
-                const pos = new Vector3(0, 0, 0);
+                const pos = new Vector3(0, 0, 2);
                 if (respawnRef.current) {
                     respawnRef.current.triggerSpawn(pos, shipRef.current);
                 }


### PR DESCRIPTION
## What
Respawn VFX in front of the ship model.
![image](https://github.com/user-attachments/assets/bbd2a00d-ab70-4eb7-9cfd-ded70e26429f)


## Why
It was previously spawned at the same Z axis as the ship and was therefore inside it.

## Resolves
- Resolves: #184 