### PR TITLE
Select closest proxy

### DIFF
--- a/src/examples/spaceshooter/renderer/ShipEntity.tsx
+++ b/src/examples/spaceshooter/renderer/ShipEntity.tsx
@@ -11,7 +11,6 @@ import {
     Color,
     DoubleSide,
     Group,
-    Line3,
     Mesh,
     Object3DEventMap,
     PositionalAudio as PositionalAudioImpl,
@@ -30,7 +29,6 @@ import { SparksFX, SparksFXHandle } from '../effects/FXSparksQuarks';
 import fxThrusterData from '../effects/FXThruster';
 import {
     EntityObject3D,
-    InterpolateMethod,
     InterpolateSpeed,
     assetPath,
     interpolate,

--- a/src/runtime/network/Subcluster.ts
+++ b/src/runtime/network/Subcluster.ts
@@ -51,11 +51,15 @@ export class Subcluster {
     }
 
     async getPeerInfo() {
-        return this.peers().map((p) => ({
-            peerId: p.peerId,
-            connected: !!p.connected,
-            proxy: !!p.proxies.size,
-        }));
+        return this.peers().map((p) => {
+            const proxy = p.getBestProxy();
+            return {
+                peerId: p.peerId,
+                connected: !!p.connected,
+                proxy: proxy?.peerId ?? null,
+                rtt: proxy ? proxy.getAverageRTT() : p.getAverageRTT(),
+            };
+        });
     }
 
     async stream(eventName, value, opts: any = {}) {


### PR DESCRIPTION
## what

instead of randomly distributing proxied sends over all peers who agree to proxy, just select the "closest" one.

we calculate a round trip time as an average of the last 5 ping/pong responses, then pick the proxy with the lowest RTT if we need a proxy

this could have the side effect of continually sending all your writes to a dud proxy with the lowest latency (whereas before at least some of your packets would get out as it was spread among many)

## why

it's not practical to send all your writes via just any proxy, as it might be on the other side of the planet, or in Thailand for example. 
