### PR TITLE
Client and host app versions must match to join channel

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     },
     "dependencies": {
         "@react-three/postprocessing": "^2.16.3",
+        "md5": "^2.3.0",
         "postprocessing": "^6.36.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -56,6 +57,7 @@
         "@types/eslint-config-prettier": "^6.11.3",
         "@types/eslint__js": "^8.42.3",
         "@types/libsodium-wrappers": "^0.7.14",
+        "@types/md5": "^2.3.5",
         "@types/mocha": "^10.0.7",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@react-three/postprocessing':
         specifier: ^2.16.3
         version: 2.16.3(@react-three/fiber@8.16.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.167.1))(@types/three@0.167.1)(react@18.3.1)(three@0.167.1)
+      md5:
+        specifier: ^2.3.0
+        version: 2.3.0
       postprocessing:
         specifier: ^6.36.3
         version: 6.36.3(three@0.167.1)
@@ -60,6 +63,9 @@ importers:
       '@types/libsodium-wrappers':
         specifier: ^0.7.14
         version: 0.7.14
+      '@types/md5':
+        specifier: ^2.3.5
+        version: 2.3.5
       '@types/mocha':
         specifier: ^10.0.7
         version: 10.0.7
@@ -775,6 +781,9 @@ packages:
   '@types/libsodium-wrappers@0.7.14':
     resolution: {integrity: sha512-5Kv68fXuXK0iDuUir1WPGw2R9fOZUlYlSAa0ztMcL0s0BfIDTqg9GXz8K30VJpPP3sxWhbolnQma2x+/TfkzDQ==}
 
+  '@types/md5@2.3.5':
+    resolution: {integrity: sha512-/i42wjYNgE6wf0j2bcTX6kuowmdL/6PE4IVitMpm2eYKBUuYCprdcWVK+xEF0gcV6ufMCRhtxmReGfc6hIK7Jw==}
+
   '@types/mocha@10.0.7':
     resolution: {integrity: sha512-GN8yJ1mNTcFcah/wKEFIJckJx9iJLoMSzWcfRRuxz/Jk+U6KQNnml+etbtxFK8lPjzOw3zp4Ha/kjSst9fsHYw==}
 
@@ -1140,6 +1149,9 @@ packages:
     resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
+  charenc@0.0.2:
+    resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
+
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
     engines: {node: '>= 16'}
@@ -1189,6 +1201,9 @@ packages:
   cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
     engines: {node: '>= 8'}
+
+  crypt@0.0.2:
+    resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -1681,6 +1696,9 @@ packages:
     resolution: {integrity: sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==}
     engines: {node: '>= 0.4'}
 
+  is-buffer@1.1.6:
+    resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
+
   is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
@@ -1992,6 +2010,9 @@ packages:
   make-dir@2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
     engines: {node: '>=6'}
+
+  md5@2.3.0:
+    resolution: {integrity: sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==}
 
   memorystream@0.3.1:
     resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
@@ -3436,6 +3457,8 @@ snapshots:
 
   '@types/libsodium-wrappers@0.7.14': {}
 
+  '@types/md5@2.3.5': {}
+
   '@types/mocha@10.0.7': {}
 
   '@types/node@10.17.60': {}
@@ -3902,6 +3925,8 @@ snapshots:
 
   chalk@5.3.0: {}
 
+  charenc@0.0.2: {}
+
   check-error@2.1.1: {}
 
   chokidar@3.6.0:
@@ -3963,6 +3988,8 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  crypt@0.0.2: {}
 
   cssesc@3.0.0: {}
 
@@ -4564,6 +4591,8 @@ snapshots:
       call-bind: 1.0.7
       has-tostringtag: 1.0.2
 
+  is-buffer@1.1.6: {}
+
   is-callable@1.2.7: {}
 
   is-core-module@2.15.0:
@@ -4842,6 +4871,12 @@ snapshots:
       pify: 4.0.1
       semver: 5.7.2
     optional: true
+
+  md5@2.3.0:
+    dependencies:
+      charenc: 0.0.2
+      crypt: 0.0.2
+      is-buffer: 1.1.6
 
   memorystream@0.3.1: {}
 

--- a/src/gui/components/ChannelBoot.tsx
+++ b/src/gui/components/ChannelBoot.tsx
@@ -1,11 +1,14 @@
-import md5 from 'md5';
 import { memo, useMemo } from 'react';
 import { config as socketConfig } from 'socket:application';
 import { BOOTSTRAP_PEERS } from '../../runtime/bootstrap';
 import { NETWORK_ID } from '../../runtime/config';
 import { DB } from '../../runtime/db';
 import { sleep } from '../../runtime/timers';
-import { getVersionStringFromConfig } from '../../runtime/utils';
+import {
+    getVersionNumberHash,
+    getVersionStringFromConfig,
+    splitChannelCode,
+} from '../../runtime/utils';
 import { ClientContextType, useClient } from '../hooks/use-client';
 import { useCredentials } from '../hooks/use-credentials';
 import { useDatabase } from '../hooks/use-database';
@@ -289,14 +292,15 @@ const terminalFlow = ({
                         reject('invalid key');
                         return;
                     }
-                    const [channelId, hostVersionHash] = input.split(':');
+                    const { channelId, hostVersionHash } =
+                        splitChannelCode(input);
                     if (!hostVersionHash) {
                         reject('invalid key');
                         return;
                     }
-                    const clientVersionHash = md5(
+                    const clientVersionHash = getVersionNumberHash(
                         getVersionStringFromConfig(socketConfig),
-                    ).slice(0, 4);
+                    );
                     if (hostVersionHash !== clientVersionHash) {
                         reject('client app version incompatible with host');
                         return;

--- a/src/gui/components/ChannelBoot.tsx
+++ b/src/gui/components/ChannelBoot.tsx
@@ -1,9 +1,10 @@
 import { memo, useMemo } from 'react';
-import { config } from 'socket:application';
+import { config as socketConfig } from 'socket:application';
 import { BOOTSTRAP_PEERS } from '../../runtime/bootstrap';
 import { NETWORK_ID } from '../../runtime/config';
 import { DB } from '../../runtime/db';
 import { sleep } from '../../runtime/timers';
+import { getVersionStringFromConfig } from '../../runtime/utils';
 import { ClientContextType, useClient } from '../hooks/use-client';
 import { useCredentials } from '../hooks/use-credentials';
 import { useDatabase } from '../hooks/use-database';
@@ -49,11 +50,7 @@ const terminalFlow = ({
                 await sleep(TERM_DELAY);
                 return (
                     <>
-                        {config['meta_title'].indexOf('v:') > -1 ? (
-                            <p>v{config['meta_title'].split('v:')[1]}</p>
-                        ) : (
-                            <p>v{config['meta_version']}</p>
-                        )}
+                        <p>v{getVersionStringFromConfig(socketConfig)}</p>
                         <br />
                     </>
                 );

--- a/src/gui/components/ChannelBoot.tsx
+++ b/src/gui/components/ChannelBoot.tsx
@@ -1,3 +1,4 @@
+import md5 from 'md5';
 import { memo, useMemo } from 'react';
 import { config as socketConfig } from 'socket:application';
 import { BOOTSTRAP_PEERS } from '../../runtime/bootstrap';
@@ -288,8 +289,21 @@ const terminalFlow = ({
                         reject('invalid key');
                         return;
                     }
+                    const [channelId, hostVersionHash] = input.split(':');
+                    if (!hostVersionHash) {
+                        reject('invalid key');
+                        return;
+                    }
+                    const clientVersionHash = md5(
+                        getVersionStringFromConfig(socketConfig),
+                    ).slice(0, 4);
+                    if (hostVersionHash !== clientVersionHash) {
+                        reject('client app version incompatible with host');
+                        return;
+                    }
+
                     client
-                        .joinChannel(input)
+                        .joinChannel(channelId)
                         .then(() => {
                             resolve('OK');
                         })

--- a/src/gui/components/ChannelView.tsx
+++ b/src/gui/components/ChannelView.tsx
@@ -1,11 +1,13 @@
 import { useLiveQuery } from 'dexie-react-hooks';
+import md5 from 'md5';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { config as socketConfig } from 'socket:application';
 import { SESSION_TIME_SECONDS } from '../../examples/spaceshooter';
 import { ChannelInfo } from '../../runtime/channels';
 import { PeerInfo } from '../../runtime/db';
 import { DefaultMetrics } from '../../runtime/metrics';
 import { sleep } from '../../runtime/timers';
-import { hardReset } from '../../runtime/utils';
+import { getVersionStringFromConfig, hardReset } from '../../runtime/utils';
 import { getPlayerColorUi } from '../fixtures/player-colors';
 import { useClient } from '../hooks/use-client';
 import { useCredentials } from '../hooks/use-credentials';
@@ -32,6 +34,14 @@ export const SIM_END = SESSION_TIME_SECONDS / (FIXED_UPDATE_RATE / 1000);
 
 const src = '/examples/spaceshooter.js'; // not a real src yet see runtime/game.ts
 
+const getChannelCode = (channelId: string) => {
+    return (
+        channelId +
+        ':' +
+        md5(getVersionStringFromConfig(socketConfig)).slice(0, 4)
+    );
+};
+
 export default memo(function ChannelView({
     channel,
     details,
@@ -48,9 +58,11 @@ export default memo(function ChannelView({
     const [showConnectedPeers, setShowConnectedPeers] = useState(false);
 
     const copyKeyToClipboard = () => {
-        navigator.clipboard.writeText(channel.id).catch((err) => {
-            console.error('clipboard write failed:', err);
-        });
+        navigator.clipboard
+            .writeText(getChannelCode(channel.id))
+            .catch((err) => {
+                console.error('clipboard write failed:', err);
+            });
     };
 
     const socket = useSocket();
@@ -207,7 +219,7 @@ export default memo(function ChannelView({
                             alignItems: 'center',
                         }}
                     >
-                        {channel.id}{' '}
+                        {getChannelCode(channel.id)}{' '}
                         <span
                             className={`${theme.materialSymbolsOutlined} ${termstyles.promptTextColor}`}
                             style={{ padding: '0 4px', cursor: 'pointer' }}

--- a/src/gui/components/ChannelView.tsx
+++ b/src/gui/components/ChannelView.tsx
@@ -134,6 +134,14 @@ export default memo(function ChannelView({
         [],
     );
 
+    const peerVersions = useLiveQuery(
+        () => {
+            return db.peerVesions.toArray();
+        },
+        [],
+        [],
+    );
+
     // a peer is "ready" if it can see all other peers
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const required = channel
@@ -299,7 +307,17 @@ export default memo(function ChannelView({
                         {peerNames.find((p) => p.peerId === channel.creator)
                             ?.name || channel.creator.slice(0, 8)}
                     </span>{' '}
-                    to confirm peers
+                    to confirm peers.
+                    <br />
+                    Using version{' '}
+                    <span style={{ color: 'white' }}>
+                        v
+                        {
+                            peerVersions.find(
+                                (p) => p.peerId === channel.creator,
+                            )?.version
+                        }
+                    </span>{' '}
                 </span>
             ),
             promise: () =>

--- a/src/gui/components/ChannelView.tsx
+++ b/src/gui/components/ChannelView.tsx
@@ -1,5 +1,4 @@
 import { useLiveQuery } from 'dexie-react-hooks';
-import md5 from 'md5';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { config as socketConfig } from 'socket:application';
 import { SESSION_TIME_SECONDS } from '../../examples/spaceshooter';
@@ -7,7 +6,7 @@ import { ChannelInfo } from '../../runtime/channels';
 import { PeerInfo } from '../../runtime/db';
 import { DefaultMetrics } from '../../runtime/metrics';
 import { sleep } from '../../runtime/timers';
-import { getVersionStringFromConfig, hardReset } from '../../runtime/utils';
+import { getChannelCode, hardReset } from '../../runtime/utils';
 import { getPlayerColorUi } from '../fixtures/player-colors';
 import { useClient } from '../hooks/use-client';
 import { useCredentials } from '../hooks/use-credentials';
@@ -34,14 +33,6 @@ export const SIM_END = SESSION_TIME_SECONDS / (FIXED_UPDATE_RATE / 1000);
 
 const src = '/examples/spaceshooter.js'; // not a real src yet see runtime/game.ts
 
-const getChannelCode = (channelId: string) => {
-    return (
-        channelId +
-        ':' +
-        md5(getVersionStringFromConfig(socketConfig)).slice(0, 4)
-    );
-};
-
 export default memo(function ChannelView({
     channel,
     details,
@@ -59,7 +50,7 @@ export default memo(function ChannelView({
 
     const copyKeyToClipboard = () => {
         navigator.clipboard
-            .writeText(getChannelCode(channel.id))
+            .writeText(getChannelCode(channel.id, socketConfig))
             .catch((err) => {
                 console.error('clipboard write failed:', err);
             });
@@ -219,7 +210,7 @@ export default memo(function ChannelView({
                             alignItems: 'center',
                         }}
                     >
-                        {getChannelCode(channel.id)}{' '}
+                        {getChannelCode(channel.id, socketConfig)}{' '}
                         <span
                             className={`${theme.materialSymbolsOutlined} ${termstyles.promptTextColor}`}
                             style={{ padding: '0 4px', cursor: 'pointer' }}

--- a/src/gui/components/Titlebar.tsx
+++ b/src/gui/components/Titlebar.tsx
@@ -1,3 +1,5 @@
+import { config as socketConfig } from 'socket:application';
+import { getVersionStringFromConfig } from '../../runtime/utils';
 import theme from '../styles/default.module.css';
 import { isWindows } from '../system/menu';
 
@@ -37,7 +39,9 @@ export function Titlebar({
                     flexGrow: 1,
                 }}
             >
-                <strong>Playerchain Demo</strong>
+                <strong>
+                    Playerchain Demo v{getVersionStringFromConfig(socketConfig)}
+                </strong>
             </div>
             <div
                 style={{

--- a/src/runtime/channels.ts
+++ b/src/runtime/channels.ts
@@ -55,6 +55,7 @@ export class Channel {
     lastKnowPeers = new Map<string, PeerStatus>();
     alivePeerIds: Map<string, KeepAliveMessage> = new Map();
     peerNames: Map<string, string> = new Map();
+    peerVersions: Map<string, string> = new Map();
     loopTimer: NodeJS.Timeout | null = null;
     looping = false;
 
@@ -171,7 +172,7 @@ export class Channel {
                 console.error('update-peer-err:', err);
             });
         if (!this.peerNames.has(peerId)) {
-            console.log('setitng peer name', peerId, m.name);
+            console.log('setting peer name', peerId, m.name);
             this.client.db.peerNames
                 .put({
                     peerId: peerId,
@@ -181,6 +182,19 @@ export class Channel {
                     console.error('update-peer-name-err:', err);
                 });
             this.peerNames.set(peerId, m.name);
+        }
+
+        if (!this.peerVersions.has(peerId)) {
+            console.log('setting peer version', peerId, m.name);
+            this.client.db.peerVesions
+                .put({
+                    peerId: peerId,
+                    version: m.version,
+                })
+                .catch((err) => {
+                    console.error('update-peer-version-err:', err);
+                });
+            this.peerVersions.set(peerId, m.version);
         }
     };
 

--- a/src/runtime/channels.ts
+++ b/src/runtime/channels.ts
@@ -1,4 +1,5 @@
 import * as Comlink from 'comlink';
+import { config as socketConfig } from 'socket:application';
 import { Buffer } from 'socket:buffer';
 import { v6 as uuidv6 } from 'uuid';
 import { Client } from './client';
@@ -12,6 +13,7 @@ import {
 } from './messages';
 import { SocketEmitOpts } from './network';
 import { Subcluster } from './network/Subcluster';
+import { getVersionStringFromConfig } from './utils';
 
 export type ChannelConfig = {
     id: string;
@@ -197,6 +199,7 @@ export class Channel {
                     ) as unknown as Uint8Array,
             ),
             name: peerName?.name || '',
+            version: getVersionStringFromConfig(socketConfig),
         };
         const opts = { ttl: 60 * 1000 };
         await this.send(msg, opts);

--- a/src/runtime/db.ts
+++ b/src/runtime/db.ts
@@ -74,9 +74,14 @@ export type PlayerSettings = {
     muted?: boolean;
 };
 
-export type PeerNames = {
+export type PeerName = {
     peerId: string;
     name: string;
+};
+
+export type PeerVersions = {
+    peerId: string;
+    version: string;
 };
 
 export type MessageConfirmationMatrix = [
@@ -226,7 +231,8 @@ export type DB = Dexie & {
     peers: EntityTable<PeerInfo, 'peerId'>;
     network: EntityTable<NetworkInfo, 'id'>;
     settings: EntityTable<PlayerSettings, 'id'>;
-    peerNames: EntityTable<PeerNames, 'peerId'>;
+    peerNames: EntityTable<PeerName, 'peerId'>;
+    peerVesions: EntityTable<PeerVersions, 'peerId'>;
     tapes: EntityTable<Tape>;
     chat: EntityTable<StoredChatMessage, 'id'>;
 };
@@ -243,6 +249,7 @@ export function open(name: string): DB {
         network: 'id',
         settings: 'id',
         peerNames: 'peerId',
+        peerVesions: 'peerId',
         tapes: '[channel+round], [channel+updated]',
         chat: 'id, arrived',
     });

--- a/src/runtime/messages.ts
+++ b/src/runtime/messages.ts
@@ -24,6 +24,7 @@ export type KeepAliveMessage = {
     name: string;
     timestamp: number;
     sees: Uint8Array[];
+    version: string;
 };
 
 export type ChatMessage = {
@@ -103,17 +104,19 @@ function encodeKeepAliveMessage(p: KeepAliveMessage): Uint8Array {
         p.name,
         p.timestamp,
         p.sees,
+        p.version,
     ]);
 }
 
 function decodeKeepAliveMessage(props: any[]): KeepAliveMessage {
-    const [peer, name, timestamp, sees] = props;
+    const [peer, name, timestamp, sees, version] = props;
     return {
         type: MessageType.KEEP_ALIVE,
         peer,
         name,
         timestamp,
         sees,
+        version,
     };
 }
 

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -1,4 +1,5 @@
 import Dexie from 'dexie';
+import md5 from 'md5';
 
 // stop vite being a nob and just let me do a dynamic import
 export async function importStatic(modulePath) {
@@ -49,4 +50,25 @@ export function getVersionStringFromConfig(socketConfig: any) {
     return socketConfig['meta_title'].indexOf('v:') > -1
         ? socketConfig['meta_title'].split('v:')[1]
         : socketConfig['meta_version'];
+}
+
+export function getVersionNumberHash(version: string) {
+    return md5(version).slice(0, 4);
+}
+
+const CHANNEL_CODE_DELIMITER = ':';
+
+export function getChannelCode(channelId: string, socketConfig: any) {
+    return (
+        channelId +
+        CHANNEL_CODE_DELIMITER +
+        getVersionNumberHash(getVersionStringFromConfig(socketConfig))
+    );
+}
+
+export function splitChannelCode(channelCode: string) {
+    const [channelId, hostVersionHash] = channelCode.split(
+        CHANNEL_CODE_DELIMITER,
+    );
+    return { channelId, hostVersionHash };
 }

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -44,3 +44,9 @@ export async function hardReset(dbname?: string) {
 export function ByRandom() {
     return 0.5 - Math.random();
 }
+
+export function getVersionStringFromConfig(socketConfig: any) {
+    return socketConfig['meta_title'].indexOf('v:') > -1
+        ? socketConfig['meta_title'].split('v:')[1]
+        : socketConfig['meta_version'];
+}


### PR DESCRIPTION
# What

encoded at the end of the invite code is the hash of the app version number. If the hash on the invite code doesn't match the hash of the client that is trying to join the channel, an error message will be displayed

# How
I'm md5 hashing the version number and taking the first 4 characters from it. This is concatenated at the end of the channelId using `:` as the delimeter to split the two apart. As it's a simple string comparrison any non empty string could come after the delimeter.

# Notes
To set a version number at build set the `VERSION` environment variable. This is then used when generating the `socket.ini` file

fixes: #60 #61