### PR TITLE
Game would hang on loader after reset

### DIFF
--- a/src/gui/providers/ClientProvider.tsx
+++ b/src/gui/providers/ClientProvider.tsx
@@ -1,12 +1,21 @@
 import * as Comlink from 'comlink';
-import React from 'react';
+import { useLiveQuery } from 'dexie-react-hooks';
+import React, { useEffect } from 'react';
+import { NETWORK_ID } from '../../runtime/config';
 import { Loading } from '../components/Loading';
 import { useAsyncMemo } from '../hooks/use-async';
 import { ClientContext, ClientContextType } from '../hooks/use-client';
 import { useCredentials } from '../hooks/use-credentials';
+import { useDatabase } from '../hooks/use-database';
 
 export const ClientProvider = ({ children }: { children: React.ReactNode }) => {
+    const [resetCount, setResetCount] = React.useState(0);
+    const [isReady, setIsReady] = React.useState(false);
     const { keys, dbname } = useCredentials();
+    const db = useDatabase();
+    const network = useLiveQuery(() => {
+        return db.network.get(NETWORK_ID);
+    }, []);
 
     console.log('client provider render');
 
@@ -44,11 +53,29 @@ export const ClientProvider = ({ children }: { children: React.ReactNode }) => {
             console.log(`${dbname} worker ready`);
             return c;
         },
-        [keys, dbname],
+        [keys, dbname, resetCount],
     );
 
+    useEffect(() => {
+        if (isReady && !network) {
+            console.log(
+                'Network settings missing after client init! Resetting client...',
+            );
+            setIsReady(false);
+            setResetCount((prev) => prev + 1);
+            return;
+        }
+        if (client && network) {
+            setIsReady(true);
+        }
+    }, [client, isReady, network]);
+
     if (!client) {
-        return <Loading />;
+        return <div>no client</div>;
+    }
+
+    if (!network) {
+        return <div>no network settings</div>;
     }
 
     return (

--- a/src/gui/providers/SettingsProvider.tsx
+++ b/src/gui/providers/SettingsProvider.tsx
@@ -13,7 +13,7 @@ export const SettingsProvider = ({
     const settings = useLiveQuery(() => {
         return db.settings.get(1);
     }, []);
-    console.log('settings render');
+    console.log('settings render. settings:', settings);
 
     useEffect(() => {
         db.settings
@@ -42,7 +42,7 @@ export const SettingsProvider = ({
                 }
             })
             .catch((err) => console.error('settings-add-err:', err));
-    }, [db]);
+    }, [db, settings]);
 
     if (!settings) {
         return <Loading />;


### PR DESCRIPTION
# What

I have added some code to recreate settings and restart the network client if the game gets into a state where the database has been cleared after the game has initialised

# Why

With two windows open and doing a hard reset in the first window, the database on the second window would get cleared after the window had already partially initiallised. This would cause a problem where settings would get created by the effect in the provider, the settings being cleared when the database is reset and the settings effect not rerunning as the 'db' dependency on the effect wouldn't change. By adding 'settings' as a dependency it will trigger the effect to recreate them if they are cleared

After fixing this the was the same problem with the client provider. The client would be created and initialised which causes the network settings to be stored in the db. The db is cleared after the client has initialised where we are in a state where we have an initialised client but no network settings and this would cause the game to hang at 'generating client keypair' in the terminal flow as it will wait indefinitely for the network settings to be created. I solved this by adding an effect that checks if the client has been initialised but with missing network settings. I increment 'resetCount' which causes the client to be shutdown and restarted. If this is too heavy handed I think I could make the effect call 'init' on the client again but I wasn't sure if it would play nicely being initialised twice

maybe fixes #225