### PR TITLE
include apache licence for network bits

### DIFF
--- a/src/runtime/network/LICENCE.txt
+++ b/src/runtime/network/LICENCE.txt
@@ -1,0 +1,21 @@
+Apache License
+
+Copyright 2023 Paolo Fragomeni <paolo@socketsupply.co>
+Copyright 2023 Joseph Werle <joseph@socketsupply.co>
+Copyright 2023 Sergey Rubanov <sergey@socketsupply.co>
+Copyright 2022 Jake Verbaten
+Copyright 2022 Serge Zaitsev
+
+Copyright 2023 Socket Supply Co.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/src/runtime/network/README.md
+++ b/src/runtime/network/README.md
@@ -1,0 +1,3 @@
+### p2p network
+
+code in this directory is derrived from the "latica" protocol from [socket](https://github.com/socketsupply/socket/tree/master) and Licensed under the Apache License, Version 2.0. See [LICENCE](./LICENCE.txt)


### PR DESCRIPTION
## what

we ported and modified the latica protocol from socket, which is Apache licenced. Make sure to include the original licence for that.

## why

to be a good FOSS netizen.