### PR TITLE
tooltip to show proxy info (if applicable)

### DIFF
--- a/src/gui/components/ChannelView.tsx
+++ b/src/gui/components/ChannelView.tsx
@@ -2,6 +2,7 @@ import { useLiveQuery } from 'dexie-react-hooks';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { config as socketConfig } from 'socket:application';
 import { SESSION_TIME_SECONDS } from '../../examples/spaceshooter';
+import { getProxyName } from '../../runtime/bootstrap';
 import { ChannelInfo } from '../../runtime/channels';
 import { PeerInfo } from '../../runtime/db';
 import { DefaultMetrics } from '../../runtime/metrics';
@@ -594,9 +595,11 @@ function PeerStatus({
         }
     }
     const green = '#339129';
+    const tooltip = `last seen: ${lastSeen}ms ago\nconnected: ${info?.connected ? 'yes' : 'no'}\nproxy: ${info?.proxy ? getProxyName(info.proxy) : 'none'}`;
 
     return (
         <div
+            title={tooltip}
             style={{
                 display: 'flex',
                 flexDirection: 'row',

--- a/src/runtime/bootstrap.ts
+++ b/src/runtime/bootstrap.ts
@@ -60,3 +60,17 @@ export const BOOTSTRAP_PEERS = [
         indexed: true,
     },
 ].sort(() => Math.random() - 0.5);
+
+// debug helper for checking if one of the boostrap peers is proxying for us
+export function getProxyName(peerId: string): string {
+    for (const peer of BOOTSTRAP_PEERS) {
+        if (peer.peerId === peerId) {
+            if (peer.address === northEurope) {
+                return 'NorthEurope';
+            } else if (peer.address === southEastAsia) {
+                return 'SouthEastAsia';
+            }
+        }
+    }
+    return `Peer ${peerId.slice(0, 8)}`;
+}

--- a/src/runtime/channels.ts
+++ b/src/runtime/channels.ts
@@ -31,7 +31,7 @@ export interface ChannelInfo {
 
 export type PeerStatus = {
     connected: number;
-    proxy: boolean;
+    proxy: string | null;
 };
 
 export interface EmitOpts extends SocketEmitOpts {
@@ -92,14 +92,14 @@ export class Channel {
                 // this.onPeerLeave(peerId);
                 await this.updatePeer(peerId, {
                     connected: 0,
-                    proxy: false,
+                    proxy: null,
                 });
             }
         }
         // check for added peers
         for (const peer of peers) {
             const connected = peer.connected ? 1 : 0;
-            const proxy = !!peer.proxy;
+            const proxy = peer.proxy ? peer.proxy : null;
             let status = this.lastKnowPeers.get(peer.peerId);
             // console.log(
             //     `[${this.client.shortId}] PEER=${peer.peerId.slice(0, 8)} PROXY=${peer.proxy} RTT=${peer.rtt}`,

--- a/src/runtime/db.ts
+++ b/src/runtime/db.ts
@@ -32,7 +32,7 @@ export interface PeerInfo {
     validHeight: number;
     knownHeight: number;
     channels: string[];
-    proxy: boolean | null; // if true, then messages are bouncing off someone else
+    proxy: string | null; // if true, then messages are bouncing off someone else
     sees: string[]; // list of peers this peer has told us it knows about
 }
 

--- a/src/runtime/network/Subcluster.ts
+++ b/src/runtime/network/Subcluster.ts
@@ -56,7 +56,7 @@ export class Subcluster {
             return {
                 peerId: p.peerId,
                 connected: !!p.connected,
-                proxy: proxy?.peerId ?? null,
+                proxy: proxy?.peerId ? proxy.peerId : null,
                 rtt: proxy ? proxy.getAverageRTT() : p.getAverageRTT(),
             };
         });


### PR DESCRIPTION
## what

add a little tooltip to the peer status rows that will show which proxy you are connected to (if you are connecetd to one)

![Screenshot 2024-10-28 at 11 41 02](https://github.com/user-attachments/assets/f70582c6-8f25-427f-997b-34892d8b02fc)


## why

so that we have a way of checking which peer is acting as a proxy at runtime to help live debugging situations ... it's a bit hidden, but at the moment it's mostly for internal use

* resolves: #220 