### PR TITLE
avoid setting version in meta title

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -96,7 +96,7 @@ jobs:
               env:
                   APPLE_ID: ${{ secrets.APPLE_ID }}
                   APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
-                  VERSION: '${{ github.ref_name }}'
+                  SS_VERSION: '${{ github.ref_name }}'
               run: |
                   ssc --version
                   pnpm install
@@ -178,7 +178,7 @@ jobs:
             - name: build app
               working-directory: './app'
               env:
-                  VERSION: '${{ github.ref_name }}'
+                  SS_VERSION: '${{ github.ref_name }}'
               run: |
                   ssc --version
                   pnpm install
@@ -250,7 +250,7 @@ jobs:
             # - name: build app
             #   working-directory: './app'
             #   env:
-            #       VERSION: '${{ github.ref_name }}'
+            #       SS_VERSION: '${{ github.ref_name }}'
             #   run: |
             #       ssc --version
             #       pnpm install

--- a/socket.template.ini
+++ b/socket.template.ini
@@ -67,13 +67,11 @@ file_limit = 1024
 lang = "en-us"
 maintainer = "Playmint"
 title = "PlayerchainDemo"
-<% if (process.env['VERSION']) { %>
+<% if (process.env['SS_VERSION']) { %>
 ; NOTE: Socket doesn't properly support semver versioning, it will fail to build if there are any alpha numeric chars
-version = "<%= process.env['VERSION'].split('-')[0].replace('v','') %>"
-title = "PlayerchainDemo v:<%= process.env['VERSION'] %>"
+version = "<%= process.env['SS_VERSION'].replace(/[^0-9]+/g,'.').replace(/^[.]|[.]$/g,'').split('.').slice(0,3).join('.') %>"
 <% } else { %>
 version = "0.0.1"
-title = "PlayerchainDemo v:v0.0.1-dev"
 <% } %>
 
 [android]

--- a/src/gui/components/ChannelBoot.tsx
+++ b/src/gui/components/ChannelBoot.tsx
@@ -1,5 +1,4 @@
 import { memo, useMemo } from 'react';
-import { config as socketConfig } from 'socket:application';
 import { BOOTSTRAP_PEERS } from '../../runtime/bootstrap';
 import { NETWORK_ID } from '../../runtime/config';
 import { DB } from '../../runtime/db';
@@ -7,7 +6,7 @@ import { sleep } from '../../runtime/timers';
 import { hardReset } from '../../runtime/utils';
 import {
     getVersionNumberHash,
-    getVersionStringFromConfig,
+    getVersionString,
     splitChannelCode,
 } from '../../runtime/utils';
 import { ClientContextType, useClient } from '../hooks/use-client';
@@ -55,7 +54,7 @@ const terminalFlow = ({
                 await sleep(TERM_DELAY);
                 return (
                     <>
-                        <p>{getVersionStringFromConfig(socketConfig)}</p>
+                        <p>{getVersionString()}</p>
                         <br />
                     </>
                 );
@@ -314,9 +313,8 @@ const terminalFlow = ({
                         reject('invalid key');
                         return;
                     }
-                    const clientVersionHash = getVersionNumberHash(
-                        getVersionStringFromConfig(socketConfig),
-                    );
+                    const clientVersionHash =
+                        getVersionNumberHash(getVersionString());
                     if (hostVersionHash !== clientVersionHash) {
                         reject('client app version incompatible with host');
                         return;

--- a/src/gui/components/ChannelView.tsx
+++ b/src/gui/components/ChannelView.tsx
@@ -1,6 +1,5 @@
 import { useLiveQuery } from 'dexie-react-hooks';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { config as socketConfig } from 'socket:application';
 import { SESSION_TIME_SECONDS } from '../../examples/spaceshooter';
 import { getProxyName } from '../../runtime/bootstrap';
 import { ChannelInfo } from '../../runtime/channels';
@@ -52,7 +51,7 @@ export default memo(function ChannelView({
 
     const copyKeyToClipboard = () => {
         navigator.clipboard
-            .writeText(getChannelCode(channel.id, socketConfig))
+            .writeText(getChannelCode(channel.id))
             .catch((err) => {
                 console.error('clipboard write failed:', err);
             });
@@ -202,7 +201,7 @@ export default memo(function ChannelView({
                             alignItems: 'center',
                         }}
                     >
-                        {getChannelCode(channel.id, socketConfig)}{' '}
+                        {getChannelCode(channel.id)}{' '}
                         <span
                             className={`${theme.materialSymbolsOutlined} ${termstyles.promptTextColor}`}
                             style={{ padding: '0 4px', cursor: 'pointer' }}

--- a/src/gui/components/Titlebar.tsx
+++ b/src/gui/components/Titlebar.tsx
@@ -1,5 +1,4 @@
-import { config as socketConfig } from 'socket:application';
-import { getVersionStringFromConfig } from '../../runtime/utils';
+import { getVersionString } from '../../runtime/utils';
 import theme from '../styles/default.module.css';
 import { isWindows } from '../system/menu';
 
@@ -39,9 +38,7 @@ export function Titlebar({
                     flexGrow: 1,
                 }}
             >
-                <strong>
-                    Playerchain Demo {getVersionStringFromConfig(socketConfig)}
-                </strong>
+                <strong>Playerchain Demo {getVersionString()}</strong>
             </div>
             <div
                 style={{

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -46,10 +46,8 @@ export function ByRandom() {
     return 0.5 - Math.random();
 }
 
-export function getVersionStringFromConfig(socketConfig: any) {
-    return socketConfig['meta_title'].indexOf('v:') > -1
-        ? socketConfig['meta_title'].split('v:')[1]
-        : socketConfig['meta_version'];
+export function getVersionString() {
+    return import.meta.env.SS_VERSION || 'dev';
 }
 
 export function getVersionNumberHash(version: string) {
@@ -58,11 +56,11 @@ export function getVersionNumberHash(version: string) {
 
 const CHANNEL_CODE_DELIMITER = ':';
 
-export function getChannelCode(channelId: string, socketConfig: any) {
+export function getChannelCode(channelId: string) {
     return (
         channelId +
         CHANNEL_CODE_DELIMITER +
-        getVersionNumberHash(getVersionStringFromConfig(socketConfig))
+        getVersionNumberHash(getVersionString())
     );
 }
 


### PR DESCRIPTION
## what

* added the SS_ prefix to the environment variable so that we can read on `import.meta.env`
* get the version number from the `SS_VERSION` environment variable at runtime rather than parsing it from the application meta.title

## why

because the meta.title shows up on Windows builds in the app switcher / title so it looks bit funny with the version tag in it

* resolves: #250 